### PR TITLE
reinjector augmented for link and processor failure dumped packets. 

### DIFF
--- a/c_models/reinjector/reinjector.c
+++ b/c_models/reinjector/reinjector.c
@@ -256,30 +256,28 @@ INT_HANDLER dropped_packet_callback() {
                 n_link_dumped_packets +=
                     __builtin_popcount(is_link_dump);
             }
-            if(is_processor_dump == 0 && n_link_dumped_packets == 0){
 
-                // Only update this counter if this is a packet to reinject
-                n_dropped_packets += 1;
+            // Only update this counter if this is a packet to reinject
+            n_dropped_packets += 1;
 
-                // try to insert dumped packet in the queue,
-                uint new_tail = (pkt_queue.tail + 1) % PKT_QUEUE_SIZE;
+            // try to insert dumped packet in the queue,
+            uint new_tail = (pkt_queue.tail + 1) % PKT_QUEUE_SIZE;
 
-                // check for space in the queue
-                if (new_tail != pkt_queue.head) {
+            // check for space in the queue
+            if (new_tail != pkt_queue.head) {
 
-                    // queue packet,
-                    pkt_queue.queue[pkt_queue.tail].hdr = hdr;
-                    pkt_queue.queue[pkt_queue.tail].key = key;
-                    pkt_queue.queue[pkt_queue.tail].pld = pld;
+                // queue packet,
+                pkt_queue.queue[pkt_queue.tail].hdr = hdr;
+                pkt_queue.queue[pkt_queue.tail].key = key;
+                pkt_queue.queue[pkt_queue.tail].pld = pld;
 
-                    // update queue pointer,
-                    pkt_queue.tail = new_tail;
+                // update queue pointer,
+                pkt_queue.tail = new_tail;
 
-                } else {
+            } else {
 
-                    // The queue of packets has overflowed
-                    n_dropped_packet_overflows += 1;
-                }
+                // The queue of packets has overflowed
+                n_dropped_packet_overflows += 1;
             }
         }
     }

--- a/spinnman/model/dpri_status.py
+++ b/spinnman/model/dpri_status.py
@@ -18,7 +18,8 @@ class DPRIStatus(object):
         (self._router_timeout, self._router_emergency_timeout,
          self._n_dropped_packets, self._n_missed_dropped_packets,
          self._n_dropped_packet_overflows, self._n_reinjected_packets,
-         self._flags) = struct.unpack_from("<IIIIIII", data, offset)
+         self._n_link_dumps, self._n_processor_dumps,
+         self._flags) = struct.unpack_from("<IIIIIIIII", data, offset)
 
     @property
     def router_timeout(self):
@@ -55,6 +56,24 @@ class DPRIStatus(object):
             having enough space in the queue of packets to reinject
         """
         return self._n_dropped_packet_overflows
+
+    @property
+    def n_processor_dumps(self):
+        """ The number of times that when a dropped packet was caused due to
+        a processor failing to take the packet.
+
+        :return: int
+        """
+        return self._n_processor_dumps
+
+    @property
+    def n_link_dumps(self):
+        """ The number of times that when a dropped packet was caused due to
+        a link failing to take the packet.
+
+        :return: int
+        """
+        return self._n_link_dumps
 
     @property
     def n_reinjected_packets(self):


### PR DESCRIPTION
fixes: 
fixing the reinjector so that it wont reinject packets that were dumped from going down a link or by a failed processor. Also to add said provenance data items accordingly.  

modules this fix is associated with 
1. SpiNNMan
1. FEC
- [x] documented code changes. 
- [x] fix reinjector.c
- [x] fix provenance data items.

github markers
- [x] updated bug/feature flags.
- [x] updated github developers associated with.
- [x] updated schedule for when this pull request should be completed.

tests that need to be done to verify that the change hasnt affected preexisting functionality.
- [x] test for failed link (use external devices without a device)
- [x] test for failed processor (use gfe arbitrary example)
- [x] spynnaker external devices tests.
- [x] spynnaker test basic reads for v (use synfire).
- [x] spynnaker test basic read for gsyn (use synfire).
- [x] spynnaker test basic read for spikes (use synfire).
- [x] spynnaker test multiple reads and writes (use synfire).
- [x] spynnaker test no reads and writes (use synfire).
- [x] spynnaker test ssa recording (use synfire).
- [x] spynnaker test poission recording (used pynn brunnel).
- [x] spynnaker test poission no recording (use pynn brunnel).
- [x] spynnaker test auto pause and resume battery of tests.
- [x] spynnaker test va benchmark from spynnaker.
- [ ] spynnaker test with microcircuit 10 % model.
- [ ] spynnaker test with microcircuit 100 % model.
- [x] GFE test heat demo code.
- [x] GFE test hello world. 
- [x] GFE test ray tracer. 
- [x] GFE test conways partitioned batch of examples.
- [x] test with live extraction (is being ignored at date as auto_pause-and_resume works).
- [x] test reload (use synfire) (has been disabled till a plan of action on it is decided).

documentation changes
- [x] changed workshop slides accordingly.
- [x] changed gitio pages accordingly.
  
  verification of changes from team members
- [x] verified team member 1.
- [ ] verified team member 2.
