### PR TITLE
Double check that test board is reachable!

### DIFF
--- a/board_test_configuration.py
+++ b/board_test_configuration.py
@@ -2,6 +2,16 @@ import socket
 import ConfigParser
 import os
 from spinnman.model.bmp_connection_data import BMPConnectionData
+import platform
+import subprocess
+import unittest
+import time
+
+_LOCALHOST = "127.0.0.1"
+# Microsoft invalid IP address. For more details see:
+# http://answers.microsoft.com/en-us/windows/forum/windows_vista-networking/invalid-ip-address-169254xx/ce096728-e2b7-4d54-80cc-52a4ed342870
+_NOHOST = "169.254.254.254"
+_PORT = 54321
 
 
 class BoardTestConfiguration(object):
@@ -18,14 +28,15 @@ class BoardTestConfiguration(object):
         self._config.read(config_file)
 
     def set_up_local_virtual_board(self):
-        self.localhost = "127.0.0.1"
-        self.localport = 54321
-        self.remotehost = "127.0.0.1"
+        self.localhost = _LOCALHOST
+        self.localport = _PORT
+        self.remotehost = _LOCALHOST
         self.board_version = self._config.getint("Machine", "version")
 
     def set_up_remote_board(self):
-
         self.remotehost = self._config.get("Machine", "machineName")
+        if not self.host_is_reachable(self.remotehost):
+            raise unittest.SkipTest("test board appears to be down")
         self.board_version = self._config.getint("Machine", "version")
         self.bmp_names = self._config.get("Machine", "bmp_names")
         if self.bmp_names == "None":
@@ -37,13 +48,27 @@ class BoardTestConfiguration(object):
             self._config.getboolean("Machine", "auto_detect_bmp")
         self.localport = 54321
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((self.remotehost, 0))
-        self.localhost = s.getsockname()[0]
+        try:
+            s.connect((self.remotehost, 0))
+            self.localhost = s.getsockname()[0]
+        finally:
+            s.close()
 
     def set_up_nonexistent_board(self):
         self.localhost = None
-        self.localport = 54321
-        # Microsoft invalid IP address. For more details see:
-        # http://answers.microsoft.com/en-us/windows/forum/windows_vista-networking/invalid-ip-address-169254xx/ce096728-e2b7-4d54-80cc-52a4ed342870
-        self.remotehost = "169.254.254.254"
+        self.localport = _PORT
+        self.remotehost = _NOHOST
         self.board_version = self._config.getint("Machine", "version")
+
+    @staticmethod
+    def host_is_reachable(ipaddr):
+        if platform.platform().lower().startswith("windows"):
+            cmd = "ping -n 1 -w 1 "
+        else:
+            cmd = "ping -c 1 -W 1 "
+        process = subprocess.Popen(
+            cmd + ipaddr, shell=True, stdout=subprocess.PIPE)
+        time.sleep(1.2)
+        process.stdout.close()
+        process.wait()
+        return process.returncode == 0


### PR DESCRIPTION
We can't guarantee that boards are going to be up all the time, so tests that are effectively integration tests need to be resistant to problems caused by the board being absent. This adds a check for whether the board is up to the setup code called in each test that needs an actual board, skipping if the board can't be pinged (itself a proxy for a proper test, but a reasonably simple one).

(This is prompted by `spinn-2` being incidentally down at the moment.)