### PR TITLE
made log message always happen so integration tests can count 

### DIFF
--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -971,10 +971,10 @@ class Transceiver(object):
                 " supported, and might be removed in a future version")
 
         # try to get a scamp version once
+        logger.info("Working out if machine is booted")
         if self._machine_off:
             version_info = None
         else:
-            logger.info("Working out if machine is booted")
             version_info = self._try_to_find_scamp_and_boot(
                 INITIAL_FIND_SCAMP_RETRIES_COUNT, number_of_boards,
                 width, height)


### PR DESCRIPTION
power save turns on machine multiple times.

this log message was used to count the number of times machine was turned on.

So needs to happen even if machine is currently off.
