### PR TITLE
Encoding and decoding of binary data should use precompiled patterns.

### DIFF
--- a/spinnman/connections/udp_packet_connections/bmp_connection.py
+++ b/spinnman/connections/udp_packet_connections/bmp_connection.py
@@ -7,6 +7,9 @@ from spinnman.messages.scp.enums import SCPResult
 from spinnman.connections.abstract_classes \
     import SCPReceiver, SCPSender
 
+_TWO_SHORTS = struct.Struct("<2H")
+_TWO_SKIP = struct.Struct("<2x")
+
 
 class BMPConnection(
         UDPConnection, SCPReceiver, SCPSender):
@@ -86,11 +89,11 @@ class BMPConnection(
 
     def get_scp_data(self, scp_request):
         update_sdp_header_for_udp_send(scp_request.sdp_header, 0, 0)
-        return struct.pack("<2x") + scp_request.bytestring
+        return _TWO_SKIP.pack() + scp_request.bytestring
 
     def receive_scp_response(self, timeout=1.0):
         data = self.receive(timeout)
-        result, sequence = struct.unpack_from("<2H", data, 10)
+        result, sequence = _TWO_SHORTS.unpack_from(data, 10)
         return SCPResult(result), sequence, data, 2
 
     def send_scp_request(self, scp_request):

--- a/spinnman/connections/udp_packet_connections/eieio_connection.py
+++ b/spinnman/connections/udp_packet_connections/eieio_connection.py
@@ -6,6 +6,7 @@ from spinnman.messages.eieio \
 
 import struct
 
+_ONE_SHORT = struct.Struct("<H")
 _REPR_TEMPLATE = "EIEIOConnection(local_host={}, local_port={},"\
     "remote_host={}, remote_port={})"
 
@@ -41,7 +42,7 @@ class EIEIOConnection(
 
     def receive_eieio_message(self, timeout=None):
         data = self.receive(timeout)
-        header = struct.unpack_from("<H", data)[0]
+        header = _ONE_SHORT.unpack_from(data)[0]
         if header & 0xC000 == 0x4000:
             return read_eieio_command_message(data, 0)
         else:

--- a/spinnman/connections/udp_packet_connections/scamp_connection.py
+++ b/spinnman/connections/udp_packet_connections/scamp_connection.py
@@ -7,6 +7,9 @@ from .sdp_connection import SDPConnection
 from spinnman.connections.abstract_classes \
     import SCPSender, SCPReceiver
 
+_TWO_SHORTS = struct.Struct("<2H")
+_TWO_SKIP = struct.Struct("<2x")
+
 
 class SCAMPConnection(
         SDPConnection, SCPSender, SCPReceiver):
@@ -61,11 +64,11 @@ class SCAMPConnection(
     def get_scp_data(self, scp_request):
         update_sdp_header_for_udp_send(scp_request.sdp_header,
                                        self._chip_x, self._chip_y)
-        return struct.pack("<2x") + scp_request.bytestring
+        return _TWO_SKIP.pack() + scp_request.bytestring
 
     def receive_scp_response(self, timeout=1.0):
         data = self.receive(timeout)
-        result, sequence = struct.unpack_from("<2H", data, 10)
+        result, sequence = _TWO_SHORTS.unpack_from(data, 10)
         return SCPResult(result), sequence, data, 2
 
     def send_scp_request(self, scp_request):

--- a/spinnman/connections/udp_packet_connections/sdp_connection.py
+++ b/spinnman/connections/udp_packet_connections/sdp_connection.py
@@ -6,6 +6,8 @@ from spinnman.connections.abstract_classes \
 
 import struct
 
+_TWO_SKIP = struct.Struct("<2x")
+
 
 class SDPConnection(
         UDPConnection, SDPReceiver, SDPSender,
@@ -57,7 +59,7 @@ class SDPConnection(
                 sdp_message.sdp_header, self._chip_x, self._chip_y)
         else:
             update_sdp_header_for_udp_send(sdp_message.sdp_header, 0, 0)
-        self.send(struct.pack("<2x") + sdp_message.bytestring)
+        self.send(_TWO_SKIP.pack() + sdp_message.bytestring)
 
     def get_receive_method(self):
         return self.receive_sdp_message

--- a/spinnman/messages/eieio/command_messages/eieio_command_header.py
+++ b/spinnman/messages/eieio/command_messages/eieio_command_header.py
@@ -1,6 +1,8 @@
 from spinnman.exceptions import SpinnmanInvalidParameterException
 import struct
 
+_ONE_SHORT = struct.Struct("<H")
+
 
 class EIEIOCommandHeader(object):
     """ EIEIO header for command packets
@@ -33,7 +35,7 @@ class EIEIOCommandHeader(object):
         :raise spinnman.exceptions.SpinnmanInvalidParameterException: If there\
                     is an error setting any of the values
         """
-        command_header = struct.unpack_from("<H", data, offset)[0]
+        command_header = _ONE_SHORT.unpack_from(data, offset)[0]
         command = command_header & 0x3FFF
 
         return EIEIOCommandHeader(command)
@@ -44,4 +46,4 @@ class EIEIOCommandHeader(object):
 
         :rtype: str
         """
-        return struct.pack("<H", 0 << 15 | 1 << 14 | self._command)
+        return _ONE_SHORT.pack(0 << 15 | 1 << 14 | self._command)

--- a/spinnman/messages/eieio/command_messages/host_data_read.py
+++ b/spinnman/messages/eieio/command_messages/host_data_read.py
@@ -5,6 +5,9 @@ from .eieio_command_header import EIEIOCommandHeader
 from spinnman.constants import EIEIO_COMMAND_IDS
 import struct
 
+_PATTERN_BB = struct.Struct("<BB")
+_PATTERN_xxBBI = struct.Struct("<xxBBI")
+
 
 class HostDataRead(EIEIOCommandMessage):
     """ Packet sent by the host computer to the SpiNNaker system in the\
@@ -60,9 +63,8 @@ class HostDataRead(EIEIOCommandMessage):
         return 8
 
     @staticmethod
-    def from_bytestring(command_header, data, offset):
-        n_requests, sequence_no = struct.unpack_from(
-            "<BB", data, offset)
+    def from_bytestring(command_header, data, offset):  # @UnusedVariable
+        n_requests, sequence_no = _PATTERN_BB.unpack_from(data, offset)
 
         offset += 2
         n_requests &= 0x7
@@ -72,7 +74,7 @@ class HostDataRead(EIEIOCommandMessage):
 
         for _ in xrange(n_requests):
             channel_ack, region_id_ack, space_read_ack = \
-                struct.unpack_from("<xxBBI", data, offset)
+                _PATTERN_xxBBI.unpack_from(data, offset)
             channel.append(channel_ack)
             region_id.append(region_id_ack)
             space_read.append(space_read_ack)
@@ -84,11 +86,10 @@ class HostDataRead(EIEIOCommandMessage):
     def bytestring(self):
         byte_string = super(HostDataRead, self).bytestring
         n_requests = self.n_requests
-        byte_string += struct.pack("<BB", n_requests, self.sequence_no)
+        byte_string += _PATTERN_BB.pack(n_requests, self.sequence_no)
         for i in xrange(n_requests):
-            byte_string += struct.pack(
-                "<xxBBI", self.channel(i), self.region_id(i),
-                self.space_read(i))
+            byte_string += _PATTERN_xxBBI.pack(
+                self.channel(i), self.region_id(i), self.space_read(i))
         return byte_string
 
 

--- a/spinnman/messages/eieio/command_messages/host_send_sequenced_data.py
+++ b/spinnman/messages/eieio/command_messages/host_send_sequenced_data.py
@@ -4,6 +4,8 @@ from spinnman.constants import EIEIO_COMMAND_IDS
 from spinnman.messages.eieio.create_eieio_data import read_eieio_data_message
 import struct
 
+_PATTERN_BB = struct.Struct("<BB")
+
 
 class HostSendSequencedData(EIEIOCommandMessage):
     """ Packet sent from the host to the SpiNNaker system in the context of\
@@ -35,14 +37,14 @@ class HostSendSequencedData(EIEIOCommandMessage):
         return 4
 
     @staticmethod
-    def from_bytestring(command_header, data, offset):
-        region_id, sequence_no = struct.unpack_from("<BB", data, offset)
+    def from_bytestring(command_header, data, offset):  # @UnusedVariable
+        region_id, sequence_no = _PATTERN_BB.unpack_from(data, offset)
         eieio_data_message = read_eieio_data_message(data, offset)
-        return HostSendSequencedData(region_id, sequence_no,
-                                     eieio_data_message)
+        return HostSendSequencedData(
+            region_id, sequence_no, eieio_data_message)
 
     @property
     def bytestring(self):
-        return (super(HostSendSequencedData, self).bytestring + struct.pack(
-            "<BB", self._region_id, self._sequence_no) +
-            self._eieio_data_message.bytestring)
+        return (super(HostSendSequencedData, self).bytestring +
+                _PATTERN_BB.pack(self._region_id, self._sequence_no) +
+                self._eieio_data_message.bytestring)

--- a/spinnman/messages/eieio/command_messages/spinnaker_request_buffers.py
+++ b/spinnman/messages/eieio/command_messages/spinnaker_request_buffers.py
@@ -3,6 +3,8 @@ from .eieio_command_header import EIEIOCommandHeader
 from spinnman.constants import EIEIO_COMMAND_IDS
 import struct
 
+_PATTERN_BBBxBBI = struct.Struct("<BBBxBBI")
+
 
 class SpinnakerRequestBuffers(EIEIOCommandMessage):
     """ Message used in the context of the buffering input mechanism which is\
@@ -49,15 +51,16 @@ class SpinnakerRequestBuffers(EIEIOCommandMessage):
         return 12
 
     @staticmethod
-    def from_bytestring(command_header, data, offset):
-        y, x, processor, region_id, sequence_no, space = struct.unpack_from(
-            "<BBBxBBI", data, offset)
+    def from_bytestring(command_header, data, offset):  # @UnusedVariable
+        y, x, processor, region_id, sequence_no, space = \
+            _PATTERN_BBBxBBI.unpack_from(data, offset)
         p = (processor >> 3) & 0x1F
         return SpinnakerRequestBuffers(x, y, p, region_id & 0xF, sequence_no,
                                        space)
 
     @property
     def bytestring(self):
-        return (super(SpinnakerRequestBuffers, self).bytestring + struct.pack(
-            "<BBBxBBI", self._y, self._x, self._p << 3, self._region_id,
-            self._sequence_no, self._space_available))
+        return (super(SpinnakerRequestBuffers, self).bytestring +
+                _PATTERN_BBBxBBI.pack(
+                    self._y, self._x, self._p << 3, self._region_id,
+                    self._sequence_no, self._space_available))

--- a/spinnman/messages/eieio/command_messages/spinnaker_request_read_data.py
+++ b/spinnman/messages/eieio/command_messages/spinnaker_request_read_data.py
@@ -5,6 +5,12 @@ from .eieio_command_header import EIEIOCommandHeader
 from spinnman.constants import EIEIO_COMMAND_IDS
 import struct
 
+_PATTERN_BBBB = struct.Struct("<BBBB")
+_PATTERN_BBII = struct.Struct("<BBII")
+_PATTERN_xxBBII = struct.Struct("<xxBBII")
+_PATTERN_BB = struct.Struct("<BB")
+_PATTERN_BBBBII = struct.Struct("<BBBBII")
+
 
 class SpinnakerRequestReadData(EIEIOCommandMessage):
     """ Message used in the context of the buffering output mechanism which is\
@@ -84,7 +90,7 @@ class SpinnakerRequestReadData(EIEIOCommandMessage):
     @staticmethod
     def from_bytestring(command_header, data, offset):
         (y, x, processor_and_requests, sequence_no) = \
-            struct.unpack_from("<BBBB", data, offset)
+            _PATTERN_BBBB.unpack_from(data, offset)
         p = (processor_and_requests >> 3) & 0x1F
         n_requests = processor_and_requests & 0x7
         offset += 4
@@ -96,13 +102,13 @@ class SpinnakerRequestReadData(EIEIOCommandMessage):
         for i in xrange(n_requests):
             if i == 0:
                 request_channel, request_region_id, request_start_address, \
-                    request_space_to_be_read = struct.unpack_from(
-                        "<BBII", data, offset)
+                    request_space_to_be_read = _PATTERN_BBII.unpack_from(
+                        data, offset)
                 offset += 10
             else:
                 request_channel, request_region_id, request_start_address, \
-                    request_space_to_be_read = struct.unpack_from(
-                        "<xxBBII", data, offset)
+                    request_space_to_be_read = _PATTERN_xxBBII.unpack_from(
+                        data, offset)
                 offset += 12
             channel.append(request_channel)
             region_id.append(request_region_id)
@@ -115,19 +121,19 @@ class SpinnakerRequestReadData(EIEIOCommandMessage):
     @property
     def bytestring(self):
         byte_string = super(SpinnakerRequestReadData, self).bytestring
-        byte_string += struct.pack("<BB", self.x, self.y)
+        byte_string += _PATTERN_BB.pack(self.x, self.y)
         n_requests = self.n_requests
         processor_and_request = (self.p << 3) | n_requests
 
         for i in xrange(n_requests):
             if i == 0:
-                byte_string += struct.pack(
-                    "<BBBBII", processor_and_request, self.sequence_no,
+                byte_string += _PATTERN_BBBBII.pack(
+                    processor_and_request, self.sequence_no,
                     self.channel(i), self.region_id(i),
                     self.start_address(0), self.space_to_be_read(i))
             else:
-                byte_string += struct.pack(
-                    "<xxBBII", self.channel(i), self.region_id(i),
+                byte_string += _PATTERN_xxBBII.pack(
+                    self.channel(i), self.region_id(i),
                     self.start_address(0), self.space_to_be_read(i))
         return byte_string
 

--- a/spinnman/messages/eieio/data_messages/eieio_data_header.py
+++ b/spinnman/messages/eieio/data_messages/eieio_data_header.py
@@ -2,6 +2,16 @@ from spinnman.messages.eieio import EIEIOType, EIEIOPrefix
 from spinnman.exceptions import SpinnmanInvalidPacketException
 import struct
 
+_PATTERN_BBHH = struct.Struct("<BBHH")
+_PATTERN_BBH = struct.Struct("<BBH")
+_PATTERN_BBHI = struct.Struct("<BBHI")
+_PATTERN_BBI = struct.Struct("<BBI")
+_PATTERN_BB = struct.Struct("<BB")
+_PATTERN_HH = struct.Struct("<HH")
+_PATTERN_H = struct.Struct("<H")
+_PATTERN_HI = struct.Struct("<HI")
+_PATTERN_I = struct.Struct("<I")
+
 
 class EIEIODataHeader(object):
 
@@ -140,28 +150,24 @@ class EIEIODataHeader(object):
             if (self._eieio_type == EIEIOType.KEY_PAYLOAD_16_BIT or
                     self._eieio_type == EIEIOType.KEY_16_BIT):
                 if self._prefix is not None:
-                    return struct.pack(
-                        "<BBHH", self._count, data, self._prefix,
-                        self._payload_base)
+                    return _PATTERN_BBHH.pack(
+                        self._count, data, self._prefix, self._payload_base)
                 else:
-                    return struct.pack(
-                        "<BBH", self._count, data, self._payload_base)
+                    return _PATTERN_BBH.pack(
+                        self._count, data, self._payload_base)
             elif (self._eieio_type == EIEIOType.KEY_PAYLOAD_32_BIT or
                     self._eieio_type == EIEIOType.KEY_32_BIT):
                 if self._prefix is not None:
-                    return struct.pack(
-                        "<BBHI", self._count, data, self._prefix,
-                        self._payload_base)
+                    return _PATTERN_BBHI.pack(
+                        self._count, data, self._prefix, self._payload_base)
                 else:
-                    return struct.pack(
-                        "<BBI", self._count, data, self._payload_base)
+                    return _PATTERN_BBI.pack(
+                        self._count, data, self._payload_base)
         else:
             if self._prefix is not None:
-                return struct.pack(
-                    "<BBH", self._count, data, self._prefix)
+                return _PATTERN_BBH.pack(self._count, data, self._prefix)
             else:
-                return struct.pack(
-                    "<BB", self._count, data)
+                return _PATTERN_BB.pack(self._count, data)
 
     @staticmethod
     def from_bytestring(data, offset):
@@ -176,7 +182,7 @@ class EIEIODataHeader(object):
                     :py:class:`spinnman.messages.eieio.data_messages.eieio_data_header.EIEIODataHeader`
         """
 
-        (count, header_data) = struct.unpack_from("<BB", data, offset)
+        (count, header_data) = _PATTERN_BB.unpack_from(data, offset)
 
         # Read the flags in the header
         prefix_flag = (header_data >> 7) & 1
@@ -202,22 +208,22 @@ class EIEIODataHeader(object):
             if (eieio_type == EIEIOType.KEY_16_BIT or
                     eieio_type == EIEIOType.KEY_PAYLOAD_16_BIT):
                 if prefix_flag == 1:
-                    (prefix, payload_prefix) = struct.unpack_from(
-                        "<HH", data, offset + 2)
+                    (prefix, payload_prefix) = _PATTERN_HH.unpack_from(
+                        data, offset + 2)
                 else:
-                    payload_prefix = struct.unpack_from(
-                        "<H", data, offset + 2)[0]
+                    payload_prefix = _PATTERN_H.unpack_from(
+                        data, offset + 2)[0]
             elif (eieio_type == EIEIOType.KEY_32_BIT or
                     eieio_type == EIEIOType.KEY_PAYLOAD_32_BIT):
                 if prefix_flag == 1:
-                    (prefix, payload_prefix) = struct.unpack_from(
-                        "<HI", data, offset + 2)
+                    (prefix, payload_prefix) = _PATTERN_HI.unpack_from(
+                        data, offset + 2)
                 else:
-                    payload_prefix = struct.unpack_from(
-                        "<I", data, offset + 2)[0]
+                    payload_prefix = _PATTERN_I.unpack_from(
+                        data, offset + 2)[0]
         else:
             if prefix_flag == 1:
-                prefix = struct.unpack_from("<H", data, offset + 2)[0]
+                prefix = _PATTERN_H.unpack_from(data, offset + 2)[0]
 
         return EIEIODataHeader(
             eieio_type=eieio_type, tag=tag, prefix=prefix,

--- a/spinnman/messages/eieio/data_messages/eieio_data_message.py
+++ b/spinnman/messages/eieio/data_messages/eieio_data_message.py
@@ -10,6 +10,11 @@ from .key_payload_data_element import KeyPayloadDataElement
 import math
 import struct
 
+_ONE_SHORT = struct.Struct("<H")
+_TWO_SHORTS = struct.Struct("<HH")
+_ONE_WORD = struct.Struct("<I")
+_TWO_WORDS = struct.Struct("<II")
+
 
 class EIEIODataMessage(AbstractEIEIOMessage):
     """ An EIEIO Data message
@@ -211,16 +216,16 @@ class EIEIODataMessage(AbstractEIEIOMessage):
         key = None
         payload = None
         if self._header.eieio_type == EIEIOType.KEY_16_BIT:
-            key = struct.unpack_from("<H", self._data, self._offset)[0]
+            key = _ONE_SHORT.unpack_from(self._data, self._offset)[0]
             self._offset += 2
         if self._header.eieio_type == EIEIOType.KEY_32_BIT:
-            key = struct.unpack_from("<I", self._data, self._offset)[0]
+            key = _ONE_WORD.unpack_from(self._data, self._offset)[0]
             self._offset += 4
         if self._header.eieio_type == EIEIOType.KEY_PAYLOAD_16_BIT:
-            key, payload = struct.unpack_from("<HH", self._data, self._offset)
+            key, payload = _TWO_SHORTS.unpack_from(self._data, self._offset)
             self._offset += 4
         if self._header.eieio_type == EIEIOType.KEY_PAYLOAD_32_BIT:
-            key, payload = struct.unpack_from("<II", self._data, self._offset)
+            key, payload = _TWO_WORDS.unpack_from(self._data, self._offset)
             self._offset += 8
 
         if self._header.prefix is not None:

--- a/spinnman/messages/eieio/data_messages/key_data_element.py
+++ b/spinnman/messages/eieio/data_messages/key_data_element.py
@@ -4,6 +4,9 @@ from .abstract_data_element import AbstractDataElement
 
 import struct
 
+_ONE_SHORT = struct.Struct("<H")
+_ONE_WORD = struct.Struct("<I")
+
 
 class KeyDataElement(AbstractDataElement):
     """ A data element that contains just a key
@@ -23,9 +26,9 @@ class KeyDataElement(AbstractDataElement):
                 "The type specifies a payload, but this element has no"
                 " payload")
         if eieio_type == EIEIOType.KEY_16_BIT:
-            return struct.pack("<H", self._key)
+            return _ONE_SHORT.pack(self._key)
         elif eieio_type == EIEIOType.KEY_32_BIT:
-            return struct.pack("<I", self._key)
+            return _ONE_WORD.pack(self._key)
         else:
             raise SpinnmanInvalidParameterException(
                 "eieio_type", eieio_type, "Unknown type")

--- a/spinnman/messages/eieio/data_messages/key_payload_data_element.py
+++ b/spinnman/messages/eieio/data_messages/key_payload_data_element.py
@@ -4,6 +4,9 @@ from .abstract_data_element import AbstractDataElement
 
 import struct
 
+_TWO_SHORTS = struct.Struct("<HH")
+_TWO_WORDS = struct.Struct("<II")
+
 
 class KeyPayloadDataElement(AbstractDataElement):
     """ A data element that contains a key and a payload
@@ -33,9 +36,9 @@ class KeyPayloadDataElement(AbstractDataElement):
                 "The type specifies no payload, but this element has a"
                 " payload")
         if eieio_type == EIEIOType.KEY_PAYLOAD_16_BIT:
-            return struct.pack("<HH", self._key, self._payload)
+            return _TWO_SHORTS.pack(self._key, self._payload)
         elif eieio_type == EIEIOType.KEY_PAYLOAD_32_BIT:
-            return struct.pack("<II", self._key, self._payload)
+            return _TWO_WORDS.pack(self._key, self._payload)
         else:
             raise SpinnmanInvalidParameterException(
                 "eieio_type", eieio_type, "Unknown type")

--- a/spinnman/messages/scp/abstract_messages/scp_request.py
+++ b/spinnman/messages/scp/abstract_messages/scp_request.py
@@ -3,6 +3,8 @@ import struct
 
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
+_THREE_WORDS = struct.Struct("<III")
+
 
 @add_metaclass(AbstractBase)
 class AbstractSCPRequest(object):
@@ -97,18 +99,10 @@ class AbstractSCPRequest(object):
         """
         data = (self._sdp_header.bytestring +
                 self._scp_request_header.bytestring)
-        if self._argument_1 is not None:
-            data += struct.pack("<I", self._argument_1)
-        else:
-            data += struct.pack("<I", 0)
-        if self._argument_2 is not None:
-            data += struct.pack("<I", self._argument_2)
-        else:
-            data += struct.pack("<I", 0)
-        if self._argument_3 is not None:
-            data += struct.pack("<I", self._argument_3)
-        else:
-            data += struct.pack("<I", 0)
+        data += _THREE_WORDS.pack(
+            0 if self._argument_1 is None else self._argument_1,
+            0 if self._argument_2 is None else self._argument_2,
+            0 if self._argument_3 is None else self._argument_3)
         if self._data is not None:
             data += bytes(self._data)
         return data

--- a/spinnman/messages/scp/impl/count_state_response.py
+++ b/spinnman/messages/scp/impl/count_state_response.py
@@ -25,7 +25,7 @@ class CountStateResponse(AbstractSCPResponse):
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
                 "CountState", "CMD_SIGNAL", result.name)
-        self._count = _ONE_WORD.unpack_from("<I", data, offset)[0]
+        self._count = _ONE_WORD.unpack_from(data, offset)[0]
 
     @property
     def count(self):

--- a/spinnman/messages/scp/impl/count_state_response.py
+++ b/spinnman/messages/scp/impl/count_state_response.py
@@ -4,6 +4,8 @@ from spinnman.messages.scp.abstract_messages import AbstractSCPResponse
 from spinnman.messages.scp.enums import SCPResult
 from spinnman.exceptions import SpinnmanUnexpectedResponseCodeException
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class CountStateResponse(AbstractSCPResponse):
     """ An SCP response to a request for the number of cores in a given state
@@ -23,7 +25,7 @@ class CountStateResponse(AbstractSCPResponse):
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
                 "CountState", "CMD_SIGNAL", result.name)
-        self._count = struct.unpack_from("<I", data, offset)[0]
+        self._count = _ONE_WORD.unpack_from("<I", data, offset)[0]
 
     @property
     def count(self):

--- a/spinnman/messages/scp/impl/iptag_get.py
+++ b/spinnman/messages/scp/impl/iptag_get.py
@@ -10,6 +10,8 @@ import struct
 
 _IPTAG_GET = 2
 
+_IPTAG_FORMAT = struct.Struct("<4s6s3HIH3B")
+
 
 class IPTagGet(AbstractSCPRequest):
     """ An SCP Request to get an IP tag
@@ -68,8 +70,8 @@ class _SCPIPTagGetResponse(AbstractSCPResponse):
                 "Get IP Tag Info", "CMD_IPTAG", result.name)
         (ip_address, mac_address, self._port, self._timeout,
          self._flags, self._count, self._rx_port, self._spin_chip_y,
-         self._spin_chip_x, processor_and_port) = struct.unpack_from(
-            "<4s6s3HIH3B", data, offset)
+         self._spin_chip_x, processor_and_port) = _IPTAG_FORMAT.unpack_from(
+            data, offset)
         self._ip_address = bytearray(ip_address)
         self._mac_address = bytearray(mac_address)
         self._spin_port = (processor_and_port >> 5) & 0x7

--- a/spinnman/messages/scp/impl/iptag_get_info_response.py
+++ b/spinnman/messages/scp/impl/iptag_get_info_response.py
@@ -4,6 +4,8 @@ from spinnman.messages.scp.abstract_messages import AbstractSCPResponse
 from spinnman.messages.scp.enums import SCPResult
 from spinnman.exceptions import SpinnmanUnexpectedResponseCodeException
 
+_BYTE_SKIP_BYTE_BYTE = struct.Struct("<Bx2B")
+
 
 class IPTagGetInfoResponse(AbstractSCPResponse):
     """ An SCP response to a request for information about IP tags
@@ -26,8 +28,8 @@ class IPTagGetInfoResponse(AbstractSCPResponse):
             raise SpinnmanUnexpectedResponseCodeException(
                 "Get IP Tag Info", "CMD_IPTAG", result.name)
 
-        self._tto, self._pool_size, self._fixed_size = struct.unpack_from(
-            "<Bx2B", data, offset)
+        self._tto, self._pool_size, self._fixed_size = \
+            _BYTE_SKIP_BYTE_BYTE.unpack_from(data, offset)
 
     @property
     def transient_timeout(self):

--- a/spinnman/messages/scp/impl/read_fpga_register.py
+++ b/spinnman/messages/scp/impl/read_fpga_register.py
@@ -11,6 +11,8 @@ from spinnman.exceptions import SpinnmanUnexpectedResponseCodeException
 
 import struct
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class ReadFPGARegister(BMPRequest):
     """ Requests the data from a fpga's register
@@ -59,7 +61,7 @@ class _SCPReadFPGARegisterResponse(BMPResponse):
             raise SpinnmanUnexpectedResponseCodeException(
                 "Read FPGA register", "CMD_LINK_READ", result.name)
 
-        self._fpga_register = struct.unpack_from("<I", data, offset)[0]
+        self._fpga_register = _ONE_WORD.unpack_from(data, offset)[0]
 
     @property
     def fpga_register(self):

--- a/spinnman/messages/scp/impl/router_alloc.py
+++ b/spinnman/messages/scp/impl/router_alloc.py
@@ -8,6 +8,8 @@ from spinnman.exceptions import SpinnmanUnexpectedResponseCodeException
 
 import struct
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class RouterAlloc(AbstractSCPRequest):
     """ An SCP Request to allocate space for routing entries
@@ -60,7 +62,7 @@ class _SCPRouterAllocResponse(AbstractSCPResponse):
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
                 "Router Allocation", "CMD_ALLOC", result.name)
-        self._base_address = struct.unpack_from("<I", data, offset)[0]
+        self._base_address = _ONE_WORD.unpack_from(data, offset)[0]
 
     @property
     def base_address(self):

--- a/spinnman/messages/scp/impl/sdram_alloc.py
+++ b/spinnman/messages/scp/impl/sdram_alloc.py
@@ -9,6 +9,8 @@ from spinnman.exceptions import SpinnmanInvalidParameterException
 
 import struct
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class SDRAMAlloc(AbstractSCPRequest):
     """ An SCP Request to allocate space in the SDRAM space
@@ -77,7 +79,7 @@ class _SCPSDRAMAllocResponse(AbstractSCPResponse):
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
                 "SDRAM Allocation", "CMD_ALLOC", result.name)
-        self._base_address = struct.unpack_from("<I", data, offset)[0]
+        self._base_address = _ONE_WORD.unpack_from(data, offset)[0]
 
         # check that the base address is not null (0 in python case) as
         # this reflects a issue in the command on spinnaker side

--- a/spinnman/messages/scp/impl/sdram_de_alloc.py
+++ b/spinnman/messages/scp/impl/sdram_de_alloc.py
@@ -8,6 +8,8 @@ from spinnman.exceptions import SpinnmanUnexpectedResponseCodeException
 
 import struct
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class SDRAMDeAlloc(AbstractSCPRequest):
     """ An SCP Request to free space in the SDRAM
@@ -77,8 +79,7 @@ class _SCPSDRAMDeAllocResponse(AbstractSCPResponse):
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
                 "SDRAM deallocation", "CMD_DEALLOC", result.name)
-        self._number_of_blocks_freed = struct.unpack_from(
-            "<I", data, offset)[0]
+        self._number_of_blocks_freed = _ONE_WORD.unpack_from(data, offset)[0]
 
         # check that the base address is not null (0 in python case) as
         # this reflects a issue in command on spinnaker side

--- a/spinnman/messages/scp/impl/write_fpga_register.py
+++ b/spinnman/messages/scp/impl/write_fpga_register.py
@@ -10,6 +10,8 @@ from spinnman.messages.scp import SCPRequestHeader
 from spinnman.messages.scp.enums import SCPCommand
 from .check_ok_response import CheckOKResponse
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class WriteFPGARegister(BMPRequest):
     """ A request for writing data to a FPGA register
@@ -38,7 +40,7 @@ class WriteFPGARegister(BMPRequest):
             self, board,
             SCPRequestHeader(command=SCPCommand.CMD_LINK_WRITE),
             argument_1=addr & (~0x3), argument_2=4, argument_3=fpga_num,
-            data=struct.pack("<I", value))
+            data=_ONE_WORD.pack(value))
 
     def get_scp_response(self):
         """

--- a/spinnman/messages/scp/scp_request_header.py
+++ b/spinnman/messages/scp/scp_request_header.py
@@ -1,5 +1,7 @@
 import struct
 
+_TWO_SHORTS = struct.Struct("<2H")
+
 
 class SCPRequestHeader(object):
     """ Represents the header of an SCP Request
@@ -60,4 +62,4 @@ class SCPRequestHeader(object):
         :return: The header as a bytestring
         :rtype: str
         """
-        return struct.pack("<2H", self._command.value, self._sequence)
+        return _TWO_SHORTS.pack(self._command.value, self._sequence)

--- a/spinnman/messages/scp/scp_response_header.py
+++ b/spinnman/messages/scp/scp_response_header.py
@@ -2,6 +2,8 @@ import struct
 
 from spinnman.messages.scp.enums import SCPResult
 
+_TWO_SHORTS = struct.Struct("<2H")
+
 
 class SCPResponseHeader(object):
     """ Represents the header of an SCP Response
@@ -39,5 +41,5 @@ class SCPResponseHeader(object):
         :type data: str
         :param offset:
         """
-        result, sequence = struct.unpack_from("<2H", data, offset)
+        result, sequence = _TWO_SHORTS.unpack_from(data, offset)
         return SCPResponseHeader(SCPResult(result), sequence)

--- a/spinnman/messages/sdp/sdp_header.py
+++ b/spinnman/messages/sdp/sdp_header.py
@@ -2,6 +2,7 @@ import struct
 from .sdp_flag import SDPFlag
 
 N_BYTES = 8
+_EIGHT_BYTES = struct.Struct("<8B")
 
 
 class SDPHeader(object):
@@ -249,10 +250,10 @@ class SDPHeader(object):
         source_port_cpu = (((self._source_port & 0x7) << 5) |
                            (self._source_cpu & 0x1F))
 
-        return struct.pack(
-            "<8B", self._flags.value, self._tag, dest_port_cpu,
-            source_port_cpu, self._destination_chip_y,
-            self._destination_chip_x, self._source_chip_y, self._source_chip_x)
+        return _EIGHT_BYTES.pack(
+            self._flags.value, self._tag, dest_port_cpu, source_port_cpu,
+            self._destination_chip_y, self._destination_chip_x,
+            self._source_chip_y, self._source_chip_x)
 
     @staticmethod
     def from_bytestring(data, offset):
@@ -266,8 +267,7 @@ class SDPHeader(object):
 
         (flags, tag, dest_port_cpu, source_port_cpu,
          destination_chip_y, destination_chip_x,
-         source_chip_y, source_chip_x) = struct.unpack_from(
-            "<8B", data, offset)
+         source_chip_y, source_chip_x) = _EIGHT_BYTES.unpack_from(data, offset)
         destination_port = dest_port_cpu >> 5
         destination_cpu = dest_port_cpu & 0x1F
         source_port = source_port_cpu >> 5

--- a/spinnman/messages/spinnaker_boot/spinnaker_boot_message.py
+++ b/spinnman/messages/spinnaker_boot/spinnaker_boot_message.py
@@ -3,6 +3,8 @@ from .spinnaker_boot_op_code import SpinnakerBootOpCode
 
 import struct
 
+_PATTERN_HIIII = struct.Struct(">HIIII")
+_PATTERN_2xIIII = struct.Struct("2xIIII")
 BOOT_MESSAGE_VERSION = 1
 
 
@@ -94,14 +96,14 @@ class SpinnakerBootMessage(object):
         data = ""
         if self._data is not None:
             data = self._data[self._offset:]
-        return struct.pack(
-            ">HIIII", BOOT_MESSAGE_VERSION, self._opcode.value,
+        return _PATTERN_HIIII.pack(
+            BOOT_MESSAGE_VERSION, self._opcode.value,
             self._operand_1, self._operand_2, self._operand_3) + data
 
     @staticmethod
     def from_bytestring(data, offset):
-        (opcode_value, operand_1, operand_2, operand_3) = struct.unpack_from(
-            "2xIIII", data, offset)
+        (opcode_value, operand_1, operand_2, operand_3) = \
+            _PATTERN_2xIIII.unpack_from(data, offset)
         the_data = None
         if len(data) - offset > 0:
             the_data = data

--- a/spinnman/model/adc_info.py
+++ b/spinnman/model/adc_info.py
@@ -8,6 +8,16 @@ from spinnman import constants
 # general imports
 import struct
 
+_PATTERN = struct.Struct(
+    "<"   # Little-endian
+    "8H"  # uint16_t adc[8]
+    "4h"  # int16_t t_int[4]
+    "4h"  # int16_t t_ext[4]
+    "4h"  # int16_t fan[4]
+    "I"   # uint32_t warning
+    "I")  # uint32_t shutdown
+
+
 
 class ADCInfo(object):
     """
@@ -22,15 +32,7 @@ class ADCInfo(object):
         :raise spinnman.exceptions.SpinnmanInvalidParameterException: If the\
                     message does not contain valid adc information
         """
-        data = struct.unpack_from(
-            "<"   # Little-endian
-            "8H"  # uint16_t adc[8]
-            "4h"  # int16_t t_int[4]
-            "4h"  # int16_t t_ext[4]
-            "4h"  # int16_t fan[4]
-            "I"   # uint32_t warning
-            "I",  # uint32_t shutdown
-            adc_data, offset)
+        data = _PATTERN.unpack_from(adc_data, offset)
 
         self._voltage_1_2c = data[1] * constants.BMP_V_SCALE_2_5
         self._voltage_1_2b = data[2] * constants.BMP_V_SCALE_2_5

--- a/spinnman/model/adc_info.py
+++ b/spinnman/model/adc_info.py
@@ -18,7 +18,6 @@ _PATTERN = struct.Struct(
     "I")  # uint32_t shutdown
 
 
-
 class ADCInfo(object):
     """
     container for the ADC data thats been retrieved from a fpga

--- a/spinnman/model/chip_summary_info.py
+++ b/spinnman/model/chip_summary_info.py
@@ -2,6 +2,11 @@ import struct
 
 from spinnman.model.enums import CPUState
 
+_THREE_WORDS = struct.Struct("<3I")
+_TWO_BYTES = struct.Struct("<BB")
+_FOUR_BYTES = struct.Struct("<4B")
+_EIGHTEEN_BYTES = struct.Struct("<18B")
+
 
 class ChipSummaryInfo(object):
     """ Represents the chip summary information read via an SCP command
@@ -17,8 +22,8 @@ class ChipSummaryInfo(object):
         :param y: The y-coordinate of the chip that this data is from
         """
         (chip_summary_flags, self._largest_free_sdram_block,
-            self._largest_free_sram_block) = struct.unpack_from(
-                "<3I", chip_summary_data, offset)
+            self._largest_free_sram_block) = _THREE_WORDS.unpack_from(
+                chip_summary_data, offset)
         self._n_cores = chip_summary_flags & 0x1F
         self._working_links = [
             link for link in range(0, 6)
@@ -30,7 +35,7 @@ class ChipSummaryInfo(object):
         data_offset = offset + 12
         self._core_states = [
             CPUState(state) for state in
-            struct.unpack_from("<18B", chip_summary_data, data_offset)]
+            _EIGHTEEN_BYTES.unpack_from(chip_summary_data, data_offset)]
         data_offset += 18
 
         self._x = x
@@ -41,12 +46,10 @@ class ChipSummaryInfo(object):
         self._ethernet_ip_address = None
 
         (self._nearest_ethernet_y, self._nearest_ethernet_x) = \
-            struct.unpack_from(
-                "<BB", chip_summary_data, data_offset)
+            _TWO_BYTES.unpack_from(chip_summary_data, data_offset)
         data_offset += 2
 
-        ip_data = struct.unpack_from(
-            "<4B", chip_summary_data, data_offset)
+        ip_data = _FOUR_BYTES.unpack_from(chip_summary_data, data_offset)
         ethernet_ip_address = "{}.{}.{}.{}".format(
             ip_data[0], ip_data[1], ip_data[2], ip_data[3])
         if self._is_ethernet_available:

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -5,6 +5,9 @@ from spinnman.model.enums import CPUState, RunTimeError, MailboxCommand
 CPU_INFO_BYTES = 128
 CPU_USER_0_START_ADDRESS = 112
 
+_INFO_PATTERN = struct.Struct("< 32s 3I 2B 2B 2I 2B H 3I 16s 2I 16x 4I")
+_REGISTERS_PATTERN = struct.Struct("<IIIIIIII")
+
 
 class CPUInfo(object):
     """ Represents information about the state of a CPU
@@ -40,14 +43,13 @@ class CPUInfo(object):
          self._iobuf_address, self._software_version,                # 2I  88
          # skipped                                                   # 16x 96
          user0, user1, user2, user3                                  # 4I  112
-         ) = struct.unpack_from(
-             "< 32s 3I 2B 2B 2I 2B H 3I 16s 2I 16x 4I", cpu_data, offset)
+         ) = _INFO_PATTERN.unpack_from(cpu_data, offset)
 
         index = self._application_name.find('\0')
         if index != -1:
             self._application_name = self._application_name[0:index]
 
-        self._registers = struct.unpack_from("<IIIIIIII", registers)
+        self._registers = _REGISTERS_PATTERN.unpack_from(registers)
         self._run_time_error = RunTimeError(run_time_error)
         self._state = CPUState(state)
 

--- a/spinnman/model/dpri_status.py
+++ b/spinnman/model/dpri_status.py
@@ -2,6 +2,8 @@ import struct
 
 from spinnman.messages.scp.enums import DPRIFlags
 
+_PATTERN = struct.Struct("<IIIIIIIII")
+
 
 def _decode_router_timeout_value(value):
     """ Get the timeout value of a router in ticks, given an 8-bit floating\
@@ -32,7 +34,7 @@ class DPRIStatus(object):
          self._n_dropped_packets, self._n_missed_dropped_packets,
          self._n_dropped_packet_overflows, self._n_reinjected_packets,
          self._n_link_dumps, self._n_processor_dumps,
-         self._flags) = struct.unpack_from("<IIIIIIIII", data, offset)
+         self._flags) = _PATTERN.unpack_from(data, offset)
 
     @property
     def router_timeout(self):

--- a/spinnman/model/p2p_table.py
+++ b/spinnman/model/p2p_table.py
@@ -2,6 +2,8 @@ import struct
 
 from spinnman.model.enums import P2PTableRoute
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class P2PTable(object):
     """ Represents a P2P table read from the machine
@@ -11,13 +13,12 @@ class P2PTable(object):
         self._routes = dict()
         self._width = width
         self._height = height
-        for x in range(len(column_data)):
+        for x in xrange(len(column_data)):
             y = 0
             pos = 0
             while y < height:
-                (data, offset) = column_data[x]
-                next_word = struct.unpack_from(
-                    "<I", data, offset + (pos * 4))[0]
+                data, offset = column_data[x]
+                next_word, = _ONE_WORD.unpack_from(data, offset + (pos * 4))
                 pos += 1
                 for entry in range(min(8, height - y)):
                     route = P2PTableRoute((next_word >> (3 * entry)) & 0b111)

--- a/spinnman/model/version_info.py
+++ b/spinnman/model/version_info.py
@@ -3,6 +3,8 @@ from time import localtime, asctime
 import struct
 import re
 
+_VERSION_PATTERN = struct.Struct("<BBBBHHI")
+
 
 class VersionInfo(object):
     """ Decodes SC&MP/SARK version information as returned by the SVER command
@@ -19,8 +21,8 @@ class VersionInfo(object):
                     message does not contain valid version information
         """
         (self._p, self._physical_cpu_id, self._y, self._x, _,
-            version_no, self._build_date) = struct.unpack_from(
-                "<BBBBHHI", buffer(version_data), offset)
+            version_no, self._build_date) = _VERSION_PATTERN.unpack_from(
+                buffer(version_data), offset)
 
         version_data = version_data[offset + 12:-1].decode("utf-8")
 

--- a/spinnman/processes/load_routes_process.py
+++ b/spinnman/processes/load_routes_process.py
@@ -7,6 +7,9 @@ from .write_memory_process import WriteMemoryProcess
 
 import struct
 
+_ROUTE_PATTERN = struct.Struct("<H2xIII")
+_END_PATTERN = struct.Struct("<IIII")
+
 
 class LoadMultiCastRoutesProcess(AbstractMultiConnectionProcess):
     def __init__(self, connection_selector):
@@ -25,14 +28,15 @@ class LoadMultiCastRoutesProcess(AbstractMultiConnectionProcess):
             route_entry = \
                 Router.convert_routing_table_entry_to_spinnaker_route(route)
 
-            struct.pack_into(
-                "<H2xIII", routing_data, n_entries * 16, n_entries,
+            _ROUTE_PATTERN.pack_into(
+                routing_data, n_entries * 16, n_entries,
                 route_entry, route.routing_entry_key, route.mask)
             n_entries += 1
 
         # Add an entry to mark the end
-        struct.pack_into("<IIII", routing_data, n_entries * 16,
-                         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF)
+        _END_PATTERN.pack_into(
+            routing_data, n_entries * 16,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF)
 
         # Upload the data
         table_address = 0x67800000

--- a/spinnman/processes/read_router_diagnostics_process.py
+++ b/spinnman/processes/read_router_diagnostics_process.py
@@ -5,6 +5,7 @@ from .abstract_multi_connection_process import AbstractMultiConnectionProcess
 import struct
 
 _N_REGISTERS = 16
+_ONE_WORD = struct.Struct("<I")
 
 
 class ReadRouterDiagnosticsProcess(AbstractMultiConnectionProcess):
@@ -15,17 +16,17 @@ class ReadRouterDiagnosticsProcess(AbstractMultiConnectionProcess):
         self._register_values = [0] * _N_REGISTERS
 
     def handle_control_register_response(self, response):
-        self._control_register = struct.unpack_from(
-            "<I", response.data, response.offset)[0]
+        self._control_register = _ONE_WORD.unpack_from(
+            response.data, response.offset)[0]
 
     def handle_error_status_response(self, response):
-        self._error_status = struct.unpack_from(
-            "<I", response.data, response.offset)[0]
+        self._error_status = _ONE_WORD.unpack_from(
+            response.data, response.offset)[0]
 
     def handle_register_response(self, response):
         for register in range(_N_REGISTERS):
-            self._register_values[register] = struct.unpack_from(
-                "<I", response.data, response.offset + (register * 4))[0]
+            self._register_values[register] = _ONE_WORD.unpack_from(
+                response.data, response.offset + (register * 4))[0]
 
     def get_router_diagnostics(self, x, y):
         self._send_request(ReadMemory(x, y, 0xe1000000, 4),

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -88,6 +88,11 @@ _BMP_MAJOR_VERSIONS = [1, 2]
 _STANDARD_RETIRES_NO = 3
 INITIAL_FIND_SCAMP_RETRIES_COUNT = 3
 
+_ONE_BYTE = struct.Struct("B")
+_TWO_BYTES = struct.Struct("<BB")
+_ONE_WORD = struct.Struct("<I")
+_ONE_LONG = struct.Struct("<Q")
+
 
 def create_transceiver_from_hostname(
         hostname, version, bmp_connection_data=None, number_of_boards=None,
@@ -792,8 +797,7 @@ class Transceiver(object):
         """
         if self._width is None or self._height is None:
             height_item = SystemVariableDefinition.y_size
-            self._height, self._width = struct.unpack_from(
-                "<BB",
+            self._height, self._width = _TWO_BYTES.unpack_from(
                 str(self.read_memory(
                     AbstractSCPRequest.DEFAULT_DEST_X_COORD,
                     AbstractSCPRequest.DEFAULT_DEST_Y_COORD,
@@ -1279,7 +1283,7 @@ class Transceiver(object):
                     SystemVariableDefinition.software_watchdog_count.default
 
         # build data holder
-        data = struct.pack("B", value_to_set)
+        data = _ONE_BYTE.pack(value_to_set)
 
         # write data
         base_address = (
@@ -1761,11 +1765,11 @@ class Transceiver(object):
                 x, y, cpu, base_address, reader, n_bytes)
             reader.close()
         elif isinstance(data, int):
-            data_to_write = struct.pack("<I", data)
+            data_to_write = _ONE_WORD.pack(data)
             process.write_memory_from_bytearray(
                 x, y, cpu, base_address, data_to_write, 0, 4)
         elif isinstance(data, long):
-            data_to_write = struct.pack("<Q", data)
+            data_to_write = _ONE_LONG.pack(data)
             process.write_memory_from_bytearray(
                 x, y, cpu, base_address, data_to_write, 0, 8)
         else:
@@ -1836,11 +1840,11 @@ class Transceiver(object):
             process.write_link_memory_from_reader(
                 x, y, cpu, link, base_address, data, n_bytes)
         elif isinstance(data, int):
-            data_to_write = struct.pack("<I", data)
+            data_to_write = _ONE_WORD.pack(data)
             process.write_link_memory_from_bytearray(
                 x, y, cpu, link, base_address, data_to_write, 0, 4)
         elif isinstance(data, long):
-            data_to_write = struct.pack("<Q", data)
+            data_to_write = _ONE_LONG.pack(data)
             process.write_link_memory_from_bytearray(
                 x, y, cpu, link, base_address, data_to_write, 0, 8)
         else:
@@ -1913,11 +1917,11 @@ class Transceiver(object):
                 nearest_neighbour_id, base_address, reader, n_bytes)
             reader.close()
         elif isinstance(data, int):
-            data_to_write = struct.pack("<I", data)
+            data_to_write = _ONE_WORD.pack(data)
             process.write_memory_from_bytearray(
                 nearest_neighbour_id, base_address, data_to_write, 0, 4)
         elif isinstance(data, long):
-            data_to_write = struct.pack("<Q", data)
+            data_to_write = _ONE_LONG.pack(data)
             process.write_memory_from_bytearray(
                 nearest_neighbour_id, base_address, data_to_write, 0, 8)
         else:
@@ -2626,7 +2630,7 @@ class Transceiver(object):
 
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(WriteMemory(
-            x, y, memory_position, struct.pack("<I", data_to_send)))
+            x, y, memory_position, _ONE_WORD.pack(data_to_send)))
 
     def get_router_diagnostic_filter(self, x, y, position):
         """ Gets a router diagnostic filter from a router
@@ -2661,8 +2665,8 @@ class Transceiver(object):
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         response = process.execute(
             ReadMemory(x, y, memory_position, 4))
-        return DiagnosticFilter.read_from_int(struct.unpack_from(
-            "<I", response.data, response.offset)[0])
+        return DiagnosticFilter.read_from_int(_ONE_WORD.unpack_from(
+            response.data, response.offset)[0])
 
     def clear_router_diagnostic_counters(self, x, y, enable=True,
                                          counter_ids=range(0, 16)):
@@ -2700,7 +2704,7 @@ class Transceiver(object):
                 clear_data |= 1 << counter_id + 16
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(WriteMemory(
-            x, y, 0xf100002c, struct.pack("<I", clear_data)))
+            x, y, 0xf100002c, _ONE_WORD.pack(clear_data)))
 
     @property
     def number_of_boards_located(self):


### PR DESCRIPTION
I was reading through the [struct documentation](https://docs.python.org/2/library/struct.html#classes) and I noted that it said

 > "Creating a Struct object once and calling its methods is more efficient than calling the struct functions with the same format since the format string only needs to be compiled once."
 
which I think is highly relevant to us, especially in an area that is a bit of a bottleneck. And this is a feature of a core Python library that we already use too.