### PR TITLE
Correct number of arguments to write_memory_from_bytes()

### DIFF
--- a/spinnman/processes/load_routes_process.py
+++ b/spinnman/processes/load_routes_process.py
@@ -45,7 +45,7 @@ class LoadMultiCastRoutesProcess(AbstractMultiConnectionProcess):
         table_address = 0x67800000
         process = WriteMemoryProcess(self._next_connection_selector)
         process.write_memory_from_bytearray(
-            (x, y, 0), table_address, routing_data, 0, len(routing_data))
+            x, y, 0, table_address, routing_data, 0, len(routing_data))
 
         # Allocate space in the router table
         self._send_request(RouterAlloc(x, y, app_id, n_entries),


### PR DESCRIPTION
This change fixed an incorrect number of arguments being supplied to the write_memory_from_bytes() function when called after reset. 

It seems that this is how the arguments used to be supplied, but this file has since been updated. Can you guys verify this fix doesn't go against the latest updates?