### PR TITLE
Use a documented and supported thread pool class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 six
 future
 enum34
+futures; python_version == "2.7"
 SpiNNUtilities >= 1!4.0.1, < 1!5.0.0
 SpiNNMachine >= 1!4.0.1, < 1!5.0.0
 SpiNNStorageHandlers >= 1!4.0.1, < 1!5.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         'SpiNNMachine >= 1!4.0.1, < 1!5.0.0',
         'enum34',
         'future',
+        'futures; python_version == "2.7"',
         'six']
 )


### PR DESCRIPTION
Undocumented and (presumably) unsupported classes, even when in the Python core classes, can hide all sorts of problems. Let's use something that *is* supported instead! Alas, core Python only has a supported pool class in 3, but there is a workaround for 2.7 in PyPI.
https://stackoverflow.com/a/11529742/301832
https://docs.python.org/3/library/concurrent.futures.html
https://pypi.org/project/futures/