### PR TITLE
Use a real port in the board test config

### DIFF
--- a/board_test_configuration.py
+++ b/board_test_configuration.py
@@ -46,10 +46,10 @@ class BoardTestConfiguration(object):
                 0, 0, self.bmp_names, [0], None)]
         self.auto_detect_bmp = \
             self._config.getboolean("Machine", "auto_detect_bmp")
-        self.localport = 54321
+        self.localport = _PORT
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
-            s.connect((self.remotehost, 0))
+            s.connect((self.remotehost, _PORT))
             self.localhost = s.getsockname()[0]
         finally:
             s.close()


### PR DESCRIPTION
Using a bad *remote* port causes weird effects when the board is in a
strange state. Using a real port is better since then it checks how we'd
route that. (Otherwise, when the board is reachable but otherwise
inaccessible, you get bizarre exceptions from the setup phase of the
tests.)