### PR TITLE
Exception grouping

### DIFF
--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -1,4 +1,8 @@
 import traceback
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 class SpinnmanException(Exception):
@@ -210,20 +214,81 @@ class SpinnmanUnexpectedResponseCodeException(SpinnmanException):
         return self._response
 
 
+class _Group(object):
+    def __init__(self, trace_back):
+        self.trace_back = trace_back
+        self.chip_core = "["
+        self._separator = ""
+
+    def finalise(self):
+        self.chip_core += "]"
+
+    def add_coord(self, sdp_header):
+        self.chip_core += "{}[{}:{}:{}]".format(
+            self._separator,
+            sdp_header.destination_chip_x,
+            sdp_header.destination_chip_y,
+            sdp_header.destination_cpu)
+        self._separator = ","
+
+    @staticmethod
+    def group_exceptions(error_requests, exceptions, tracebacks):
+        """ Groups exceptions into a form usable by an exception.
+
+        :param error_requests: the error requests
+        :param exceptions: the exceptions
+        :param tracebacks: the tracebacks
+        :return: a sorted exception pile
+        :rtype: dict(Exception,_Group)
+        """
+        data = OrderedDict()
+        for error_request, exception, trace_back in zip(
+                error_requests, exceptions, tracebacks):
+            for stored_exception in data.keys():
+                if isinstance(exception, type(stored_exception)):
+                    found_exception = stored_exception
+                    break
+            else:
+                data[exception] = _Group(trace_back)
+                found_exception = exception
+            data[found_exception].add_coord(error_request.sdp_header)
+        for exception in data:
+            data[exception].finalise()
+        return data.items()
+
+
+class SpinnmanGroupedProcessException(SpinnmanException):
+    """ Encapsulates exceptions from processes which communicate with a\
+        collection of cores/chips
+    """
+    def __init__(self, error_requests, exceptions, tracebacks):
+        problem = "Exceptions found were:\n"
+        for exception, description in _Group.group_exceptions(
+                error_requests, exceptions, tracebacks):
+            problem += \
+                "   Received exception class: {}\n" \
+                "       With message {}\n" \
+                "       When sending to {}\n" \
+                "       Stack trace: {}\n".format(
+                    exception.__class__.__name__, exception.message,
+                    description.chip_core,
+                    traceback.format_exc(description.trace_back))
+        super(SpinnmanGroupedProcessException, self).__init__(problem)
+
+
 class SpinnmanGenericProcessException(SpinnmanException):
     """ Encapsulates exceptions from processes which communicate with some\
         core/chip
     """
     def __init__(self, exception, tb, x, y, p, tb2=None):
         # pylint: disable=too-many-arguments
-        problem = \
-            "\n     Received exception class: {} \n" \
-            "     With message: {} \n" \
-            "     When sending to {}:{}:{}\n" \
+        super(SpinnmanGenericProcessException, self).__init__(
+            "\n     Received exception class: {} \n"
+            "     With message: {} \n"
+            "     When sending to {}:{}:{}\n"
             "     Stack trace: {}\n".format(
                 exception.__class__.__name__, str(exception), x, y, p,
-                traceback.format_tb(tb))
-        super(SpinnmanGenericProcessException, self).__init__(problem)
+                traceback.format_tb(tb)))
 
         self._stored_exception = exception
         if tb2 is not None:

--- a/spinnman/processes/abstract_process.py
+++ b/spinnman/processes/abstract_process.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 import logging
 import sys
-from spinnman.exceptions import SpinnmanGenericProcessException
+from spinnman.exceptions import (
+    SpinnmanGenericProcessException, SpinnmanGroupedProcessException)
 
 logger = logging.getLogger(__name__)
 
@@ -10,39 +11,44 @@ class AbstractProcess(object):
     """ An abstract process for talking to SpiNNaker efficiently.
     """
     __slots__ = [
-        "_error_request",
-        "_exception",
-        "_traceback"]
+        "_error_requests",
+        "_exceptions",
+        "_tracebacks"]
 
     def __init__(self):
-        self._exception = None
-        self._traceback = None
-        self._error_request = None
+        self._exceptions = []
+        self._tracebacks = []
+        self._error_requests = []
 
     def _receive_error(self, request, exception, tb):
-        self._error_request = request
-        self._exception = exception
-        self._traceback = tb
+        self._error_requests.append(request)
+        self._exceptions.append(exception)
+        self._tracebacks.append(tb)
 
     def is_error(self):
-        return self._exception is not None
+        return bool(self._exceptions)
 
     def check_for_error(self, print_exception=False):
-        if self._exception is not None:
+        if len(self._exceptions) == 1:
             exc_info = sys.exc_info()
+            sdp_header = self._error_requests[0].sdp_header
 
             if print_exception:
-                sdp_header = self._error_request.sdp_header
                 logger.error("failure in request to (%d, %d, %d)",
                              sdp_header.destination_chip_x,
                              sdp_header.destination_chip_y,
                              sdp_header.destination_cpu,
-                             exc_info=(Exception, self._exception,
-                                       self._traceback))
+                             exc_info=(Exception, self._exceptions,
+                                       self._tracebacks))
 
-            sdp_header = self._error_request.sdp_header
-            self._exception = ex = SpinnmanGenericProcessException(
-                self._exception, exc_info[2], sdp_header.destination_chip_x,
+            raise SpinnmanGenericProcessException(
+                self._exceptions[0], exc_info[2],
+                sdp_header.destination_chip_x,
                 sdp_header.destination_chip_y, sdp_header.destination_cpu,
-                self._traceback)
+                self._tracebacks[0])
+        elif self._exceptions:
+            ex = SpinnmanGroupedProcessException(
+                self._error_requests, self._exceptions, self._tracebacks)
+            if print_exception:
+                logger.error("%s", str(ex))
             raise ex


### PR DESCRIPTION
This is a mechanism for grouping exceptions that occur during the running of a transceiver process (as often the same fault occurs multiple times when it occurs at all).

Recovered from #113