### PR TITLE
Fix error cores

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,10 @@ setup(
         'future',
         'futures; python_version == "2.7"',
         'six'],
+    entry_points={
+        "console_scripts": [
+            "get_cores_in_run_state = spinnman.get_cores_in_run_state:main"]
+    },
     maintainer="SpiNNakerTeam",
     maintainer_email="spinnakerusers@googlegroups.com"
 )

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -348,3 +348,17 @@ class SpinnmanEIEIOPacketParsingException(SpinnmanException):
     @property
     def packet(self):
         return self._packet
+
+
+class SpiNNManCoresNotInStateException(SpinnmanTimeoutException):
+    """ Cores failed to reach a given state within a timeout
+    """
+
+    def __init__(self, timeout, expected_states, failed_core_states):
+        msg = "waiting for cores to reach one of {}".format(
+            expected_states)
+        super(SpiNNManCoresNotInStateException, self).__init__(msg, timeout)
+        self._failed_core_states = failed_core_states
+
+    def failed_core_states(self):
+        return self._failed_core_states

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -32,7 +32,7 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
     print('machine max x: {} max y: {}'.format(
         machine.max_chip_x, machine.max_chip_y))
     if print_all_chips:
-        print('machine chips: {}'.format(machine.chips))
+        print('machine chips: {}'.format(list(machine.chips)))
 
     all_cores = []
     for chip in machine.chips:
@@ -84,7 +84,7 @@ def main():
         help=("don't print all the chips out; avoids a great deal of "
               "output for large machines"))
     ap.add_argument(
-        "host", default=None,
+        "host", default=None, nargs='?',
         help="the hostname or IP address of the SpiNNaker machine to inspect")
     args = ap.parse_args()
     # These ought to be parsed from command line arguments

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+from spinnman.transceiver import create_transceiver_from_hostname
+from board_test_configuration import BoardTestConfiguration
+from spinn_machine import CoreSubsets, CoreSubset
+from spinnman.model.enums import CPUState
+
+SCAMP_ID = 0
+IGNORED_IDS = {SCAMP_ID, 16}  # WHY 16?
+
+
+def get_cores_in_run_state(txrx, app_id, print_all_chips):
+    count_finished = txrx.get_core_state_count(app_id, CPUState.FINISHED)
+    count_run = txrx.get_core_state_count(app_id, CPUState.RUNNING)
+    print('running: {} finished: {}'.format(count_run, count_finished))
+
+    machine = txrx.get_machine_details()
+    print('machine max x: {} max y: {}'.format(
+        machine.max_chip_x, machine.max_chip_y))
+    if print_all_chips:
+        print('machine chips: {}'.format(machine.chips))
+
+    all_cores = []
+    for chip in machine.chips:
+        all_cores.append(CoreSubset(chip.x, chip.y, range(1, 17)))
+
+    all_cores = CoreSubsets(core_subsets=all_cores)
+
+    cores_finished = txrx.get_cores_in_state(all_cores, CPUState.FINISHED)
+    cores_running = txrx.get_cores_in_state(all_cores, CPUState.RUNNING)
+    cores_watchdog = txrx.get_cores_in_state(all_cores, CPUState.WATCHDOG)
+
+    for chip in cores_running:
+        for pid in chip.processor_ids:
+            if pid not in IGNORED_IDS:
+                print('run core: {} {} {}'.format(chip.x, chip.y, pid))
+
+    for chip in cores_finished:
+        for pid in chip.processor_ids:
+            print('finished core: {} {} {}'.format(chip.x, chip.y, pid))
+
+    for chip in cores_watchdog:
+        for pid in chip.processor_ids:
+            print('watchdog core: {} {} {}'.format(chip.x, chip.y, pid))
+
+
+def make_transceiver(host=None):
+    config = BoardTestConfiguration()
+    config.set_up_remote_board()
+    if host is None:
+        host = config.remotehost
+
+    print("talking to SpiNNaker system at {}".format(host))
+    return create_transceiver_from_hostname(
+        host, config.board_version,
+        ignore_cores=CoreSubsets(),
+        ignore_chips=CoreSubsets(core_subsets=[]),
+        bmp_connection_data=config.bmp_names,
+        auto_detect_bmp=config.auto_detect_bmp)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Check the state of a SpiNNaker machine.")
+    ap.add_argument(
+        "-a", "--appid", help="the application ID to check", type=int,
+        default=17)
+    ap.add_argument(
+        "-n", "--noprintchips", action="store_true", default=False,
+        help=("don't print all the chips out; avoids a great deal of "
+              "output for large machines"))
+    ap.add_argument(
+        "host", default=None,
+        help="the hostname or IP address of the SpiNNaker machine to inspect")
+    args = ap.parse_args()
+    # These ought to be parsed from command line arguments
+    app_id = args.appid
+    print_chips = not args.noprintchips
+
+    transceiver = make_transceiver(args.host)
+    try:
+        get_cores_in_run_state(transceiver, app_id, print_chips)
+    finally:
+        transceiver.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
Add an exception which is used when cores are detected not to be in a certain state when waiting.  This can then be used in AbstractSpiNNakerBase to give more information after the event.