### PR TITLE
handle case where there is nothing to run

### DIFF
--- a/spinnman/model/executable_targets.py
+++ b/spinnman/model/executable_targets.py
@@ -44,9 +44,13 @@ class ExecutableTargets(object):
         None means dont record it.
         :return:
         """
-        for subset in subsets.core_subsets:
-            for p in subset.processor_ids:
-                self.add_processor(binary, subset.x, subset.y, p)
+        try:
+            for subset in subsets.core_subsets:
+                for p in subset.processor_ids:
+                    self.add_processor(binary, subset.x, subset.y, p)
+        except AttributeError:
+            if subsets is not None:
+                raise
         if executable_type is not None:
             self._binary_type_map[executable_type].add(binary)
 


### PR DESCRIPTION
This will anything which tries to run with nothing to run from killing the run.

Note: The trry except style rather than the pre if style choosen as error is rare at best.

This is independant of other prs with the same branch name 