### PR TITLE
Use Context Managers

### DIFF
--- a/board_test_configuration.py
+++ b/board_test_configuration.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import configparser
+from contextlib import closing
 import os
 import socket
 import unittest
@@ -61,12 +62,9 @@ class BoardTestConfiguration(object):
         self.auto_detect_bmp = \
             self._config.getboolean("Machine", "auto_detect_bmp")
         self.localport = _PORT
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        try:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as s:
             s.connect((self.remotehost, _PORT))
             self.localhost = s.getsockname()[0]
-        finally:
-            s.close()
 
     def set_up_nonexistent_board(self):
         self.localhost = None

--- a/quick_tests.py
+++ b/quick_tests.py
@@ -345,12 +345,9 @@ def print_transceiver_tests(transceiver):
             print(heap_element)
 
 
-_transceiver = create_transceiver_from_hostname(
-    board_config.remotehost, board_config.board_version,
-    ignore_cores=down_cores, ignore_chips=down_chips,
-    bmp_connection_data=board_config.bmp_names,
-    auto_detect_bmp=board_config.auto_detect_bmp)
-try:
+with create_transceiver_from_hostname(
+        board_config.remotehost, board_config.board_version,
+        ignore_cores=down_cores, ignore_chips=down_chips,
+        bmp_connection_data=board_config.bmp_names,
+        auto_detect_bmp=board_config.auto_detect_bmp) as _transceiver:
     print_transceiver_tests(_transceiver)
-finally:
-    _transceiver.close()

--- a/spinnman/connections/connection_listener.py
+++ b/spinnman/connections/connection_listener.py
@@ -75,7 +75,7 @@ class ConnectionListener(Thread, AbstractContextManager):
     def run(self):
         """ Implements the listening thread.
         """
-        try:
+        with self.__callback_pool:
             handler = self.__connection.get_receive_method()
             while not self.__done:
                 try:
@@ -84,9 +84,6 @@ class ConnectionListener(Thread, AbstractContextManager):
                     if not self.__done:
                         logger.warning("problem when dispatching message",
                                        exc_info=True)
-        finally:
-            self.__callback_pool.shutdown()
-            self.__callback_pool = None
 
     def add_callback(self, callback):
         """ Add a callback to be called when a message is received

--- a/spinnman/connections/udp_packet_connections/ip_address_connection.py
+++ b/spinnman/connections/udp_packet_connections/ip_address_connection.py
@@ -12,9 +12,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-from .udp_connection import UDPConnection
+from contextlib import suppress
 from spinnman.constants import UDP_BOOT_CONNECTION_DEFAULT_PORT
+from .udp_connection import UDPConnection
 
 _BOOTROM_SPINN_PORT = 54321  # Matches SPINN_PORT in spinnaker_bootROM
 
@@ -34,12 +34,10 @@ class IPAddressesConnection(UDPConnection):
         return False
 
     def receive_ip_address(self, timeout=None):
-        try:
+        with suppress(Exception):
             (_, (ip_address, port)) = self.receive_with_address(timeout)
             if port == _BOOTROM_SPINN_PORT:
                 return ip_address
-        except Exception:  # pylint: disable=broad-except
-            pass
         return None
 
     def __repr__(self):

--- a/spinnman/connections/udp_packet_connections/udp_connection.py
+++ b/spinnman/connections/udp_packet_connections/udp_connection.py
@@ -16,6 +16,7 @@
 import logging
 import socket
 import select
+from contextlib import suppress
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 from spinnman.exceptions import SpinnmanIOException, SpinnmanTimeoutException
@@ -211,10 +212,8 @@ class UDPConnection(Connection):
 
     @overrides(Connection.close)
     def close(self):
-        try:
+        with suppress(Exception):
             self._socket.shutdown(socket.SHUT_WR)
-        except Exception:  # pylint: disable=broad-except
-            pass
         self._socket.close()
 
     def is_ready_to_receive(self, timeout=0):

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -108,11 +108,8 @@ def main():
     except ImportError:
         print("cannot read board test configuration")
         sys.exit(1)
-    transceiver = _make_transceiver(config, args.host)
-    try:
+    with _make_transceiver(config, args.host) as transceiver:
         get_cores_in_run_state(transceiver, app_id, print_chips)
-    finally:
-        transceiver.close()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/spinnman/processes/get_machine_process.py
+++ b/spinnman/processes/get_machine_process.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import defaultdict
+from contextlib import suppress
 import logging
 import functools
 import struct
@@ -212,12 +213,10 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
         for (x, y) in p2p_table.iterchips():
             self._send_request(GetChipInfo(x, y), self._receive_chip_info)
         self._finish()
-        try:
-            self.check_for_error()
-        except Exception:  # pylint: disable=broad-except
-            # Ignore errors so far, as any error here just means that a chip
+        with suppress(Exception):
+            # Ignore errors, as any error here just means that a chip
             # is down that wasn't marked as down
-            pass
+            self.check_for_error()
 
         # Warn about unexpected missing chips
         for (x, y) in p2p_table.iterchips():

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -20,7 +20,7 @@ import random
 import struct
 from threading import Condition, RLock
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 import logging
 import socket
 import time
@@ -1035,12 +1035,10 @@ class Transceiver(AbstractContextManager):
 
         # The last thing we tried was booting, so try again to get the version
         if version_info is None:
-            try:
+            with suppress(SpinnmanException):
                 version_info = self.get_scamp_version()
                 if self.__is_default_destination(version_info):
                     version_info = None
-            except SpinnmanException:
-                pass
         if version_info is not None:
             logger.info("Found board with version {}", version_info)
         return version_info

--- a/spinnman/utilities/utility_functions.py
+++ b/spinnman/utilities/utility_functions.py
@@ -91,6 +91,8 @@ def reprogram_tag(connection, tag, strip=True):
     :param int tag: The id of the tag to set
     :param bool strip:
         True if the tag should strip SDP headers from outgoing messages
+    :raises SpinnmanTimeoutException:
+        If things time out several times
     """
     request = IPTagSet(
         connection.chip_x, connection.chip_y, [0, 0, 0, 0], 0, tag,
@@ -100,8 +102,7 @@ def reprogram_tag(connection, tag, strip=True):
     for _ in range(3):
         try:
             connection.send(data)
-            _, _, response, offset = \
-                connection.receive_scp_response()
+            _, _, response, offset = connection.receive_scp_response()
             request.get_scp_response().read_bytestring(response, offset)
             return
         except SpinnmanTimeoutException as e:


### PR DESCRIPTION
Now that we're in Python 3, we can use context managers a good deal more. This simplifies quite a few places, and gives much stronger confidence that the code concerned is correct.