### PR TITLE
Deprecate unused methods

### DIFF
--- a/spinnman/messages/scp/impl/bmp_set_led.py
+++ b/spinnman/messages/scp/impl/bmp_set_led.py
@@ -23,6 +23,9 @@ from .check_ok_response import CheckOKResponse
 
 class BMPSetLed(BMPRequest):
     """ Set the LED(s) of a board to either on, off or toggling
+
+        This class is currently deprecated and untested as there is no
+        known use except for Transceiver.set_led which is itself deprecated.
     """
     __slots__ = []
 

--- a/spinnman/messages/scp/impl/read_adc.py
+++ b/spinnman/messages/scp/impl/read_adc.py
@@ -25,6 +25,10 @@ from spinnman.model import ADCInfo
 class ReadADC(BMPRequest):
     """ SCP Request for the data from the BMP including voltages and\
         temperature.
+
+        This class is currently deprecated and untested as there is no
+        known use except for Transceiver.read_adc_data which is itself
+        deprecated.
     """
     __slots__ = []
 

--- a/spinnman/messages/scp/impl/set_led.py
+++ b/spinnman/messages/scp/impl/set_led.py
@@ -23,6 +23,9 @@ from .check_ok_response import CheckOKResponse
 
 class SetLED(AbstractSCPRequest):
     """ A request to change the state of an SetLED
+
+        This class is currently deprecated and untested as there is no
+        known use except for Transceiver.set_led which is itself deprecated.
     """
     __slots__ = []
 

--- a/spinnman/processes/de_alloc_sdram_process.py
+++ b/spinnman/processes/de_alloc_sdram_process.py
@@ -19,6 +19,11 @@ from .abstract_multi_connection_process import AbstractMultiConnectionProcess
 
 
 class DeAllocSDRAMProcess(AbstractMultiConnectionProcess):
+    """
+        This class is currently deprecated and untested as there is no
+        known use except for Transceiver.free_sdram and free_sdram_by_app_id
+        which are both themselves deprecated.
+    """
     __slots__ = [
         "_no_blocks_freed"]
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1783,8 +1783,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once(logger, "The write_neighbour_memory method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The write_neighbour_memory method is deprecated "
+                          "and untested due to no known use.")
         process = WriteMemoryProcess(self._scamp_connection_selector)
         if isinstance(data, io.RawIOBase):
             process.write_link_memory_from_reader(
@@ -2554,8 +2554,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once(logger, "The get_router_diagnostics method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The get_router_diagnostics method is deprecated "
+                          "and untested due to no known use.")
         process = ReadRouterDiagnosticsProcess(self._scamp_connection_selector)
         return process.get_router_diagnostics(x, y)
 
@@ -2685,8 +2685,8 @@ class Transceiver(AbstractContextManager):
 
         :rtype: int
         """
-        warn_once(logger, "The number_of_boards_located method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The number_of_boards_located method is deprecated "
+                          "and untested due to no known use.")
         boards = 0
         for bmp_connection in self._bmp_connections:
             boards += len(bmp_connection.boards)

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -26,6 +26,7 @@ import socket
 import time
 from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.log import FormatAdapter
+from spinn_utilities.logger_utils import warn_once
 from spinn_machine import CoreSubsets
 from spinnman.constants import (
     BMP_POST_POWER_ON_SLEEP_TIME, BMP_POWER_ON_TIMEOUT, BMP_TIMEOUT,
@@ -542,6 +543,9 @@ class Transceiver(AbstractContextManager):
     @contextmanager
     def _chip_execute_lock(self, x, y):
         """ Get a lock for executing an executable on a chip
+
+        This method is currently deprecated and untested as there is no
+        known use except for excute which is itself deprecated.
 
         :param int x:
         :param int y:
@@ -1228,6 +1232,10 @@ class Transceiver(AbstractContextManager):
         """ Enable, disable or set the value of the watch dog timer on a\
             specific chip
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :param int x: chip x coord to write new watchdog param to
         :param int y: chip y coord to write new watchdog param to
         :param watch_dog:
@@ -1237,6 +1245,8 @@ class Transceiver(AbstractContextManager):
         :type watch_dog: bool or int
         """
         # build what we expect it to be
+        warn_once("The set_watch_dog_on_chip method is deprecated and "
+                  "untested due to no known use.")
         value_to_set = watch_dog
         WATCHDOG = SystemVariableDefinition.software_watchdog_count
         if isinstance(watch_dog, bool):
@@ -1252,12 +1262,18 @@ class Transceiver(AbstractContextManager):
     def set_watch_dog(self, watch_dog):
         """ Enable, disable or set the value of the watch dog timer
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case nneded for hardware debugging.
+
         :param watch_dog:
             Either a boolean indicating whether to enable (True) or
             disable (False) the watch dog timer, or an int value to set the
             timer count to.
         :type watch_dog: bool or int
         """
+        warn_once("The set_watch_dog method is deprecated and "
+                  "untested due to no known use.")
         if self._machine is None:
             self._update_machine()
         for x, y in self._machine.chip_coordinates:
@@ -1265,6 +1281,10 @@ class Transceiver(AbstractContextManager):
 
     def get_iobuf_from_core(self, x, y, p):
         """ Get the contents of IOBUF for a given core
+
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
 
         :param int x: The x-coordinate of the chip containing the processor
         :param int y: The y-coordinate of the chip containing the processor
@@ -1281,6 +1301,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        warn_once("The get_iobuf_from_core method is deprecated and "
+                  "untested due to no known use.")
         core_subsets = CoreSubsets()
         core_subsets.add_processor(x, y, p)
         return next(self.get_iobuf(core_subsets))
@@ -1312,6 +1334,10 @@ class Transceiver(AbstractContextManager):
             self, x, y, processors, executable, app_id, n_bytes=None,
             wait=False, is_filename=False):
         """ Start an executable running on a single chip
+
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
 
         :param int x:
             The x-coordinate of the chip on which to run the executable
@@ -1353,6 +1379,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        warn_once("The Transceiver's execute method is deprecated and "
+                  "untested due to no known use.")
         # Lock against updates
         with self._chip_execute_lock(x, y):
             # Write the executable
@@ -1548,6 +1576,10 @@ class Transceiver(AbstractContextManager):
     def set_led(self, led, action, board, cabinet, frame):
         """ Set the LED state of a board in the machine
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :param led:
             Number of the LED or an iterable of LEDs to set the state of (0-7)
         :type led: int or iterable(int)
@@ -1560,6 +1592,8 @@ class Transceiver(AbstractContextManager):
         :param int cabinet: the cabinet this is targeting
         :param int frame: the frame this is targeting
         """
+        warn_once("The set_led method is deprecated and "
+                  "untested due to no known use.")
         process = SendSingleCommandProcess(
             self._bmp_connection(cabinet, frame))
         process.execute(BMPSetLed(led, action, board))
@@ -1606,12 +1640,18 @@ class Transceiver(AbstractContextManager):
     def read_adc_data(self, board, cabinet, frame):
         """ Read the BMP ADC data
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :param int cabinet: cabinet: the cabinet this is targeting
         :param int frame: the frame this is targeting
         :param int board: which board to request the ADC data from
         :return: the FPGA's ADC data object
         :rtype: ADCInfo
         """
+        warn_once("The read_adc_data method is deprecated and "
+                  "untested due to no known use.")
         process = SendSingleCommandProcess(
             self._bmp_connection(cabinet, frame))
         response = process.execute(ReadADC(board))
@@ -1743,6 +1783,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        warn_once("The write_neighbour_memory method is deprecated and "
+                  "untested due to no known use.")
         process = WriteMemoryProcess(self._scamp_connection_selector)
         if isinstance(data, io.RawIOBase):
             process.write_link_memory_from_reader(
@@ -1886,6 +1928,10 @@ class Transceiver(AbstractContextManager):
             SCP command. If sent to a BMP, this command can be used to\
             communicate with the FPGAs' debug registers.
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :param int x:
             The x-coordinate of the chip whose neighbour is to be read from
         :param int y:
@@ -1909,7 +1955,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-
+        warn_once("The read_neighbour_memory method is deprecated and "
+                  "untested due to no known use.")
         process = ReadMemoryProcess(self._scamp_connection_selector)
         return process.read_link_memory(x, y, cpu, link, base_address, length)
 
@@ -2142,6 +2189,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        warn_once("The set_leds is deprecated and "
+                  "untested due to no known use.")
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(SetLED(x, y, cpu, led_states))
 
@@ -2344,16 +2393,26 @@ class Transceiver(AbstractContextManager):
     def free_sdram(self, x, y, base_address, app_id):
         """ Free allocated SDRAM
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :param int x: The x-coordinate of the chip onto which to ask for memory
         :param int y: The y-coordinate of the chip onto which to ask for memory
         :param int base_address: The base address of the allocated memory
         :param int app_id: The app ID of the allocated memory
         """
+        warn_once("The free_sdram method is deprecated and "
+                  "untested due to no known use.")
         process = DeAllocSDRAMProcess(self._scamp_connection_selector)
         process.de_alloc_sdram(x, y, app_id, base_address)
 
     def free_sdram_by_app_id(self, x, y, app_id):
         """ Free all SDRAM allocated to a given app ID
+
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
 
         :param int x: The x-coordinate of the chip onto which to ask for memory
         :param int y: The y-coordinate of the chip onto which to ask for memory
@@ -2361,6 +2420,8 @@ class Transceiver(AbstractContextManager):
         :return: The number of blocks freed
         :rtype: int
         """
+        warn_once("The free_sdram_by_app_id method is deprecated and "
+                  "untested due to no known use.")
         process = DeAllocSDRAMProcess(self._scamp_connection_selector)
         process.de_alloc_sdram(x, y, app_id)
         return process.no_blocks_freed
@@ -2493,6 +2554,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        warn_once("The get_router_diagnostics method is deprecated and "
+                  "untested due to no known use.")
         process = ReadRouterDiagnosticsProcess(self._scamp_connection_selector)
         return process.get_router_diagnostics(x, y)
 
@@ -2616,8 +2679,14 @@ class Transceiver(AbstractContextManager):
     def number_of_boards_located(self):
         """ The number of boards currently configured.
 
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :rtype: int
         """
+        warn_once("The number_of_boards_located method is deprecated and "
+                  "untested due to no known use.")
         boards = 0
         for bmp_connection in self._bmp_connections:
             boards += len(bmp_connection.boards)
@@ -2776,8 +2845,14 @@ class Transceiver(AbstractContextManager):
     @property
     def bmp_connection(self):
         """
+        This method is currently deprecated and untested as there is no
+        known use. Same functionaility provided by ybug and bmpc.
+        Retained in case needed for hardware debugging.
+
         :rtype: dict(tuple(int,int),MostDirectConnectionSelector)
         """
+        warn_once("The bmp_connection property is deprecated and "
+                  "untested due to no known use.")
         return self._bmp_connection_selectors
 
     def get_heap(self, x, y, heap=SystemVariableDefinition.sdram_heap_address):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1282,9 +1282,7 @@ class Transceiver(AbstractContextManager):
     def get_iobuf_from_core(self, x, y, p):
         """ Get the contents of IOBUF for a given core
 
-        This method is currently deprecated and untested as there is no
-        known use. Same functionaility provided by ybug and bmpc.
-        Retained in case needed for hardware debugging.
+        This method is currently deprecated and likely to be removed.
 
         :param int x: The x-coordinate of the chip containing the processor
         :param int y: The y-coordinate of the chip containing the processor
@@ -1302,7 +1300,7 @@ class Transceiver(AbstractContextManager):
             If a response indicates an error during the exchange
         """
         warn_once(logger, "The get_iobuf_from_core method is deprecated and "
-                  "untested due to no known use.")
+                  "likely to be removed.")
         core_subsets = CoreSubsets()
         core_subsets.add_processor(x, y, p)
         return next(self.get_iobuf(core_subsets))
@@ -1335,9 +1333,7 @@ class Transceiver(AbstractContextManager):
             wait=False, is_filename=False):
         """ Start an executable running on a single chip
 
-        This method is currently deprecated and untested as there is no
-        known use. Same functionaility provided by ybug and bmpc.
-        Retained in case needed for hardware debugging.
+        This method is currently deprecated and likely to be removed.
 
         :param int x:
             The x-coordinate of the chip on which to run the executable
@@ -1380,7 +1376,7 @@ class Transceiver(AbstractContextManager):
             If a response indicates an error during the exchange
         """
         warn_once(logger, "The Transceiver's execute method is deprecated "
-                          "and untested due to no known use.")
+                          "likely to be removed.")
         # Lock against updates
         with self._chip_execute_lock(x, y):
             # Write the executable
@@ -2393,9 +2389,7 @@ class Transceiver(AbstractContextManager):
     def free_sdram(self, x, y, base_address, app_id):
         """ Free allocated SDRAM
 
-        This method is currently deprecated and untested as there is no
-        known use. Same functionaility provided by ybug and bmpc.
-        Retained in case needed for hardware debugging.
+        This method is currently deprecated and likely to be removed.
 
         :param int x: The x-coordinate of the chip onto which to ask for memory
         :param int y: The y-coordinate of the chip onto which to ask for memory
@@ -2403,7 +2397,7 @@ class Transceiver(AbstractContextManager):
         :param int app_id: The app ID of the allocated memory
         """
         warn_once(logger, "The free_sdram method is deprecated and "
-                  "untested due to no known use.")
+                  "likely to be removed.")
         process = DeAllocSDRAMProcess(self._scamp_connection_selector)
         process.de_alloc_sdram(x, y, app_id, base_address)
 
@@ -2554,8 +2548,6 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once(logger, "The get_router_diagnostics method is deprecated "
-                          "and untested due to no known use.")
         process = ReadRouterDiagnosticsProcess(self._scamp_connection_selector)
         return process.get_router_diagnostics(x, y)
 
@@ -2679,14 +2671,12 @@ class Transceiver(AbstractContextManager):
     def number_of_boards_located(self):
         """ The number of boards currently configured.
 
-        This method is currently deprecated and untested as there is no
-        known use. Same functionaility provided by ybug and bmpc.
-        Retained in case needed for hardware debugging.
+        This method is currently deprecated and likely to be removed.
 
         :rtype: int
         """
         warn_once(logger, "The number_of_boards_located method is deprecated "
-                          "and untested due to no known use.")
+                          "and likely to be removed.")
         boards = 0
         for bmp_connection in self._bmp_connections:
             boards += len(bmp_connection.boards)
@@ -2845,14 +2835,12 @@ class Transceiver(AbstractContextManager):
     @property
     def bmp_connection(self):
         """
-        This method is currently deprecated and untested as there is no
-        known use. Same functionaility provided by ybug and bmpc.
-        Retained in case needed for hardware debugging.
+        This method is currently deprecated and likely to be removed.
 
         :rtype: dict(tuple(int,int),MostDirectConnectionSelector)
         """
         warn_once(logger, "The bmp_connection property is deprecated and "
-                  "untested due to no known use.")
+                  "likely to be removed.")
         return self._bmp_connection_selectors
 
     def get_heap(self, x, y, heap=SystemVariableDefinition.sdram_heap_address):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1245,8 +1245,8 @@ class Transceiver(AbstractContextManager):
         :type watch_dog: bool or int
         """
         # build what we expect it to be
-        warn_once("The set_watch_dog_on_chip method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The set_watch_dog_on_chip method is deprecated "
+                          "and untested due to no known use.")
         value_to_set = watch_dog
         WATCHDOG = SystemVariableDefinition.software_watchdog_count
         if isinstance(watch_dog, bool):
@@ -1272,8 +1272,8 @@ class Transceiver(AbstractContextManager):
             timer count to.
         :type watch_dog: bool or int
         """
-        warn_once("The set_watch_dog method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The set_watch_dog method is deprecated and "
+                          "untested due to no known use.")
         if self._machine is None:
             self._update_machine()
         for x, y in self._machine.chip_coordinates:
@@ -1301,7 +1301,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The get_iobuf_from_core method is deprecated and "
+        warn_once(logger, "The get_iobuf_from_core method is deprecated and "
                   "untested due to no known use.")
         core_subsets = CoreSubsets()
         core_subsets.add_processor(x, y, p)
@@ -1379,8 +1379,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The Transceiver's execute method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The Transceiver's execute method is deprecated "
+                          "and untested due to no known use.")
         # Lock against updates
         with self._chip_execute_lock(x, y):
             # Write the executable
@@ -1592,7 +1592,7 @@ class Transceiver(AbstractContextManager):
         :param int cabinet: the cabinet this is targeting
         :param int frame: the frame this is targeting
         """
-        warn_once("The set_led method is deprecated and "
+        warn_once(logger, "The set_led method is deprecated and "
                   "untested due to no known use.")
         process = SendSingleCommandProcess(
             self._bmp_connection(cabinet, frame))
@@ -1650,7 +1650,7 @@ class Transceiver(AbstractContextManager):
         :return: the FPGA's ADC data object
         :rtype: ADCInfo
         """
-        warn_once("The read_adc_data method is deprecated and "
+        warn_once(logger, "The read_adc_data method is deprecated and "
                   "untested due to no known use.")
         process = SendSingleCommandProcess(
             self._bmp_connection(cabinet, frame))
@@ -1783,7 +1783,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The write_neighbour_memory method is deprecated and "
+        warn_once(logger, "The write_neighbour_memory method is deprecated and "
                   "untested due to no known use.")
         process = WriteMemoryProcess(self._scamp_connection_selector)
         if isinstance(data, io.RawIOBase):
@@ -1955,8 +1955,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The read_neighbour_memory method is deprecated and "
-                  "untested due to no known use.")
+        warn_once(logger, "The read_neighbour_memory method is deprecated "
+                  "and untested due to no known use.")
         process = ReadMemoryProcess(self._scamp_connection_selector)
         return process.read_link_memory(x, y, cpu, link, base_address, length)
 
@@ -2189,7 +2189,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The set_leds is deprecated and "
+        warn_once(logger, "The set_leds is deprecated and "
                   "untested due to no known use.")
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(SetLED(x, y, cpu, led_states))
@@ -2402,7 +2402,7 @@ class Transceiver(AbstractContextManager):
         :param int base_address: The base address of the allocated memory
         :param int app_id: The app ID of the allocated memory
         """
-        warn_once("The free_sdram method is deprecated and "
+        warn_once(logger, "The free_sdram method is deprecated and "
                   "untested due to no known use.")
         process = DeAllocSDRAMProcess(self._scamp_connection_selector)
         process.de_alloc_sdram(x, y, app_id, base_address)
@@ -2420,7 +2420,7 @@ class Transceiver(AbstractContextManager):
         :return: The number of blocks freed
         :rtype: int
         """
-        warn_once("The free_sdram_by_app_id method is deprecated and "
+        warn_once(logger, "The free_sdram_by_app_id method is deprecated and "
                   "untested due to no known use.")
         process = DeAllocSDRAMProcess(self._scamp_connection_selector)
         process.de_alloc_sdram(x, y, app_id)
@@ -2554,7 +2554,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        warn_once("The get_router_diagnostics method is deprecated and "
+        warn_once(logger, "The get_router_diagnostics method is deprecated and "
                   "untested due to no known use.")
         process = ReadRouterDiagnosticsProcess(self._scamp_connection_selector)
         return process.get_router_diagnostics(x, y)
@@ -2685,7 +2685,7 @@ class Transceiver(AbstractContextManager):
 
         :rtype: int
         """
-        warn_once("The number_of_boards_located method is deprecated and "
+        warn_once(logger, "The number_of_boards_located method is deprecated and "
                   "untested due to no known use.")
         boards = 0
         for bmp_connection in self._bmp_connections:
@@ -2851,7 +2851,7 @@ class Transceiver(AbstractContextManager):
 
         :rtype: dict(tuple(int,int),MostDirectConnectionSelector)
         """
-        warn_once("The bmp_connection property is deprecated and "
+        warn_once(logger, "The bmp_connection property is deprecated and "
                   "untested due to no known use.")
         return self._bmp_connection_selectors
 


### PR DESCRIPTION
As shown by https://github.com/SpiNNakerManchester/SpiNNMan/pull/249 and https://github.com/SpiNNakerManchester/IntegrationTests/pull/58
These methods are unused.

In discussion with @lplana and other it was decided best to keep these method and classes.