### PR TITLE
ignore bad ethernet needs to access protected variable

### DIFF
--- a/spinnman/processes/get_machine_process.py
+++ b/spinnman/processes/get_machine_process.py
@@ -240,7 +240,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
                         "This ip will not be used.",
                         chip_info.x, chip_info.y,
                         chip_info.ethernet_ip_address)
-                    chip_info.ethernet_ip_address = None
+                    chip_info._ethernet_ip_address = None
                 else:
                     logger.warning(
                         "Not using chip {}:{} as it has an unexpected "


### PR DESCRIPTION
Found by http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/no_inject/7/pipeline

WARNING: Chip 5:2 claimed it has ip address: 239.255.8.128. This ip will not be used.

AttributeError: can't set attribute

Fix. Access the projected variable.