### PR TITLE
Scamp connection cleanup.

### DIFF
--- a/spinnman/processes/most_direct_connection_selector.py
+++ b/spinnman/processes/most_direct_connection_selector.py
@@ -54,13 +54,21 @@ class MostDirectConnectionSelector(
     @overrides(
         AbstractMultiConnectionProcessConnectionSelector.get_next_connection)
     def get_next_connection(self, message):
+        key = (message.sdp_header.destination_chip_x,
+               message.sdp_header.destination_chip_y)
+        if key in self._connections:
+            return self._connections[key]
+
         if self._machine is None or len(self._connections) == 1:
             return self._first_connection
 
-        chip = self._machine.get_chip_at(
-            message.sdp_header.destination_chip_x,
-            message.sdp_header.destination_chip_y)
-        key = (chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+        (x, y) = key
+        chip = self._machine.get_chip_at(x, y)
+        if chip:
+            key = (chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+        else:
+            # Use 255, 255 as that is the connection added by transceiver init
+            key = (255, 255)
 
         if key not in self._connections:
             return self._first_connection

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -609,8 +609,6 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if ip_address in self._udp_scamp_connections:
-            return
         conn = self._search_for_proxies(x, y)
 
         # if no data, no proxy
@@ -675,6 +673,8 @@ class Transceiver(AbstractContextManager):
             ip_address = "{}.{}.{}.{}".format(*ip_address_data)
             logger.info(ip_address)
             self._check_and_add_scamp_connections(x, y, ip_address)
+        self._scamp_connection_selector = MostDirectConnectionSelector(
+            self._machine, self._scamp_connections)
 
     def add_scamp_connections(self, connections):
         """
@@ -695,6 +695,8 @@ class Transceiver(AbstractContextManager):
         """
         for ((x, y), ip_address) in connections.items():
             self._check_and_add_scamp_connections(x, y, ip_address)
+        self._scamp_connection_selector = MostDirectConnectionSelector(
+            self._machine, self._scamp_connections)
 
     def _search_for_proxies(self, x, y):
         """ Looks for an entry within the UDP SCAMP connections which is\


### PR DESCRIPTION
As this is none critical and changes low level behaviour please wait for Jenkins:
TODO

Should be merged at the same time as:
TODO

Changes include.
Allow MostDirectConnectionSelector to support multiple connections and 255,255
There will be both a 255 and a 0,0 connection to the same ip address
Note: _first_connection will be 0,0 if it exists.

use the job.connections data (if available) instead of guessing the Ethernet chips and polling to find and create scamp connections

Update the scamp_connection_selector to include connections discovered or added via Job.connections.
Messages to chip on other board will no longer go through 0,0 if possible

The _udp_scamp_connections connection for the remote_host used to create the transceiver will now point to the 0,0 connection and not the 255,255 connection with the same ipaddress
_scamp_connections and therefor scamp_connection_selector will now have both 255,255 and 0,0

The FEC Pr adds:

Writing job.connection data to the provenance databse

Getting the job.connections data to generate the machine

Calling the new add_scamp_connections method instead of discover_scamp_connections is available

TODO: The old unused way of passing scamp_connection_data as a String to machine_generator has not been removed.
Should it?

cfg spalloc_avoid_boards is now None  Removing 10.11.195.1 which we believe is a replacement board

Should a spalloc_avoid_boards be provided it now
1. Continues to replace any job with that board at 0,0
2. Removes it from job.connections so No scamp connection will be created with that ipaddress.
Therefor any message to chips on a  spalloc_avoid_boards will go via 0,0




