### PR TITLE
Whole

### DIFF
--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -17,6 +17,19 @@ import traceback
 from collections import OrderedDict
 
 
+def get_physical_cpu_id(txrx, x, y, p):
+    if txrx is None:
+        return "Unknown Physical Core"
+    try:
+        cpu_info = txrx.get_cpu_information_from_core(self, x, y, p)
+        v_to_p_map = cpu_info.virtual_to_physical_core_map
+        if p >= len(v_to_p_map) or v_to_p_map[p] == 0xFF:
+            return "Unknown Physical Core"
+        return str(v_to_p_map[p])
+    except Exception:
+        return "Unknown Physical Core"
+
+
 class SpinnmanException(Exception):
     """ Superclass of exceptions that occur when dealing with communication\
         with SpiNNaker
@@ -220,16 +233,17 @@ class _Group(object):
     def finalise(self):
         self.chip_core += "]"
 
-    def add_coord(self, sdp_header):
-        self.chip_core += "{}[{}:{}:{}]".format(
+    def add_coord(self, sdp_header, phys_p):
+        self.chip_core += "{}[{}:{}:{}({})]".format(
             self._separator,
             sdp_header.destination_chip_x,
             sdp_header.destination_chip_y,
-            sdp_header.destination_cpu)
+            sdp_header.destination_cpu, phys_p)
         self._separator = ","
 
     @staticmethod
-    def group_exceptions(error_requests, exceptions, tracebacks, connections):
+    def group_exceptions(error_requests, exceptions, tracebacks, connections,
+                         transceiver):
         """ Groups exceptions into a form usable by an exception.
 
         :param list(SCPRequest) error_requests: the error requests
@@ -237,6 +251,7 @@ class _Group(object):
         :param list tracebacks: the tracebacks
         :param list connections:
             the connections the errors were associated with
+        :param Machine machine: the machine used
         :return: a sorted exception pile
         :rtype: dict(Exception,_Group)
         """
@@ -250,7 +265,12 @@ class _Group(object):
             else:
                 data[exception] = _Group(trace_back, connection)
                 found_exception = exception
-            data[found_exception].add_coord(error_request.sdp_header)
+            sdp_header = error_request.sdp_header
+            phys_p = get_physical_cpu_id(
+                transceiver, sdp_header.destination_chip_x,
+                sdp_header.destination_chip_y,
+                sdp_header.destination_cpu)
+            data[found_exception].add_coord(sdp_header, phys_p)
         for exception in data:
             data[exception].finalise()
         return data.items()
@@ -260,10 +280,12 @@ class SpinnmanGroupedProcessException(SpinnmanException):
     """ Encapsulates exceptions from processes which communicate with a\
         collection of cores/chips
     """
-    def __init__(self, error_requests, exceptions, tracebacks, connections):
+    def __init__(self, error_requests, exceptions, tracebacks, connections,
+                 transceiver):
         problem = "Exceptions found were:\n"
         for exception, description in _Group.group_exceptions(
-                error_requests, exceptions, tracebacks, connections):
+                error_requests, exceptions, tracebacks, connections,
+                transceiver):
             problem += \
                 "   Received exception class: {}\n" \
                 "       With message {}\n" \
@@ -279,21 +301,22 @@ class SpinnmanGenericProcessException(SpinnmanException):
     """ Encapsulates exceptions from processes which communicate with some\
         core/chip
     """
-    def __init__(self, exception, tb, x, y, p, tb2=None):
+    def __init__(self, exception, tb, x, y, p, phys_p, tb2=None):
         """
         :param Exception exception:
         :param int x:
         :param int y:
         :param int p:
+        :param str phys_p:
         """
         # pylint: disable=too-many-arguments
         super().__init__(
             "\n     Received exception class: {} \n"
             "     With message: {} \n"
-            "     When sending to {}:{}:{}\n"
+            "     When sending to {}:{}:{}({})\n"
             "     Stack trace: {}\n".format(
                 exception.__class__.__name__, str(exception), x, y, p,
-                traceback.format_tb(tb)))
+                phys_p, traceback.format_tb(tb)))
 
         self._stored_exception = exception
         if tb2 is not None:

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -260,7 +260,7 @@ class _Group(object):
         :param list tracebacks: the tracebacks
         :param list connections:
             the connections the errors were associated with
-        :param Machine machine: the machine used
+        :param Transceiver transceiver: the transceiver used
         :return: a sorted exception pile
         :rtype: dict(Exception,_Group)
         """

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -21,7 +21,7 @@ def get_physical_cpu_id(txrx, x, y, p):
     if txrx is None:
         return "Unknown Physical Core"
     try:
-        cpu_info = txrx.get_cpu_information_from_core(self, x, y, p)
+        cpu_info = txrx.get_cpu_information_from_core(x, y, p)
         v_to_p_map = cpu_info.virtual_to_physical_core_map
         if p >= len(v_to_p_map) or v_to_p_map[p] == 0xFF:
             return "Unknown Physical Core"

--- a/spinnman/model/chip_info.py
+++ b/spinnman/model/chip_info.py
@@ -166,12 +166,12 @@ class ChipInfo(object):
         :rtype: bytearray
         """
         return self._physical_to_virtual_core_map
-    
+
     @property
     def virtual_to_physical_core_map(self):
         """ The virtual core ID to physical core ID map; entries with a value\
             of 0xFF are non-operational cores
-            
+
         :rtype: bytearray
         """
         return self._virtual_to_physical_core_map

--- a/spinnman/model/chip_info.py
+++ b/spinnman/model/chip_info.py
@@ -166,6 +166,15 @@ class ChipInfo(object):
         :rtype: bytearray
         """
         return self._physical_to_virtual_core_map
+    
+    @property
+    def virtual_to_physical_core_map(self):
+        """ The virtual core ID to physical core ID map; entries with a value\
+            of 0xFF are non-operational cores
+            
+        :rtype: bytearray
+        """
+        return self._virtual_to_physical_core_map
 
     @property
     def virtual_core_ids(self):

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -304,6 +304,6 @@ class CPUInfo(object):
         return self._software_version
 
     def __str__(self):
-        return "{}:{}:{:02n} {:18} {:16s} {:3n}".format(
-            self.x, self.y, self.p, self._state.name, self._application_name,
-            self._application_id)
+        return "{}:{}:{:02n} ({:02n}) {:18} {:16s} {:3n}".format(
+            self.x, self.y, self.p, self.physical_cpu_id, self._state.name,
+            self._application_name, self._application_id)

--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -86,7 +86,8 @@ class CPUInfos(object):
         return self._cpu_infos[x, y, p]
 
     def __str__(self):
-        return str(self._cpu_infos.keys())
+        return str([f"{x}, {y}, {p} (ph: {info.physical_cpu_id})" 
+                    for (x, y, p), info in self._cpu_infos.items()])
 
     def __repr__(self):
         return self.__str__()

--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -86,7 +86,7 @@ class CPUInfos(object):
         return self._cpu_infos[x, y, p]
 
     def __str__(self):
-        return str([f"{x}, {y}, {p} (ph: {info.physical_cpu_id})" 
+        return str([f"{x}, {y}, {p} (ph: {info.physical_cpu_id})"
                     for (x, y, p), info in self._cpu_infos.items()])
 
     def __repr__(self):

--- a/spinnman/processes/abstract_multi_connection_process.py
+++ b/spinnman/processes/abstract_multi_connection_process.py
@@ -62,3 +62,7 @@ class AbstractMultiConnectionProcess(AbstractProcess):
     def _finish(self):
         for request_pipeline in self._scp_request_pipelines.values():
             request_pipeline.finish()
+            
+    @property
+    def connection_selector(self):
+        return self._conn_selector

--- a/spinnman/processes/abstract_multi_connection_process.py
+++ b/spinnman/processes/abstract_multi_connection_process.py
@@ -62,7 +62,7 @@ class AbstractMultiConnectionProcess(AbstractProcess):
     def _finish(self):
         for request_pipeline in self._scp_request_pipelines.values():
             request_pipeline.finish()
-            
+
     @property
     def connection_selector(self):
         return self._conn_selector

--- a/spinnman/processes/abstract_multi_connection_process_connection_selector.py
+++ b/spinnman/processes/abstract_multi_connection_process_connection_selector.py
@@ -13,7 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 
 
 class AbstractMultiConnectionProcessConnectionSelector(
@@ -29,4 +30,9 @@ class AbstractMultiConnectionProcessConnectionSelector(
 
         :param AbstractSCPRequest message: The SCP message to be sent
         :rtype: SCAMPConnection
+        """
+    
+    @abstractproperty
+    def transceiver(self):
+        """ The transceiver from which the connections are being selected.
         """

--- a/spinnman/processes/abstract_multi_connection_process_connection_selector.py
+++ b/spinnman/processes/abstract_multi_connection_process_connection_selector.py
@@ -31,7 +31,7 @@ class AbstractMultiConnectionProcessConnectionSelector(
         :param AbstractSCPRequest message: The SCP message to be sent
         :rtype: SCAMPConnection
         """
-    
+
     @abstractproperty
     def transceiver(self):
         """ The transceiver from which the connections are being selected.

--- a/spinnman/processes/abstract_process.py
+++ b/spinnman/processes/abstract_process.py
@@ -52,7 +52,7 @@ class AbstractProcess(object, metaclass=AbstractBase):
 
     def is_error(self):
         return bool(self._exceptions)
-    
+
     @abstractproperty
     def connection_selector(self):
         """ Get the connection selector of the process
@@ -68,13 +68,13 @@ class AbstractProcess(object, metaclass=AbstractBase):
                 txrx, sdp_header.destination_chip_x,
                 sdp_header.destination_chip_y,
                 sdp_header.destination_cpu)
-                
+
             if print_exception:
                 logger.error(
                     self.ERROR_MESSAGE.format(
                         connection.remote_ip_address, connection.chip_x,
                         connection.chip_y, sdp_header.destination_chip_x,
-                        sdp_header.destination_chip_y, 
+                        sdp_header.destination_chip_y,
                         sdp_header.destination_cpu, phys_p))
 
             raise SpinnmanGenericProcessException(

--- a/spinnman/processes/abstract_single_connection_process.py
+++ b/spinnman/processes/abstract_single_connection_process.py
@@ -55,7 +55,7 @@ class AbstractSingleConnectionProcess(AbstractProcess):
 
     def _finish(self):
         self._scp_request_pipeline.finish()
-        
+
     @property
     def connection_selector(self):
         return self._connection_selector

--- a/spinnman/processes/abstract_single_connection_process.py
+++ b/spinnman/processes/abstract_single_connection_process.py
@@ -55,3 +55,7 @@ class AbstractSingleConnectionProcess(AbstractProcess):
 
     def _finish(self):
         self._scp_request_pipeline.finish()
+        
+    @property
+    def connection_selector(self):
+        return self._connection_selector

--- a/spinnman/processes/most_direct_connection_selector.py
+++ b/spinnman/processes/most_direct_connection_selector.py
@@ -25,10 +25,11 @@ class MostDirectConnectionSelector(
     __slots__ = [
         "_connections",
         "_first_connection",
-        "_machine"]
+        "_machine",
+        "_transceiver"]
 
     # pylint: disable=super-init-not-called
-    def __init__(self, machine, connections):
+    def __init__(self, machine, connections, transceiver):
         """
         :param ~spinn_machine.Machine machine:
         :param list(SCAMPConnection) connections:
@@ -44,6 +45,7 @@ class MostDirectConnectionSelector(
                 (connection.chip_x, connection.chip_y)] = connection
         if self._first_connection is None:
             self._first_connection = next(iter(connections))
+        self._transceiver = transceiver
 
     def set_machine(self, new_machine):
         """
@@ -73,3 +75,9 @@ class MostDirectConnectionSelector(
         if key not in self._connections:
             return self._first_connection
         return self._connections[key]
+    
+    @property
+    @overrides(
+        AbstractMultiConnectionProcessConnectionSelector.transceiver)
+    def transceiver(self):
+        return self._transceiver

--- a/spinnman/processes/most_direct_connection_selector.py
+++ b/spinnman/processes/most_direct_connection_selector.py
@@ -75,7 +75,7 @@ class MostDirectConnectionSelector(
         if key not in self._connections:
             return self._first_connection
         return self._connections[key]
-    
+
     @property
     @overrides(
         AbstractMultiConnectionProcessConnectionSelector.transceiver)

--- a/spinnman/processes/round_robin_connection_selector.py
+++ b/spinnman/processes/round_robin_connection_selector.py
@@ -24,15 +24,17 @@ class RoundRobinConnectionSelector(
     """
     __slots__ = [
         "_connections",
-        "_next_connection_index"]
+        "_next_connection_index",
+        "_transceiver"]
 
-    def __init__(self, connections):  # pylint: disable=super-init-not-called
+    def __init__(self, connections, transceiver):  # pylint: disable=super-init-not-called
         """
         :param list(SCAMPConnection) connections:
             The connections to be used
         """
         self._connections = connections
         self._next_connection_index = 0
+        self._transceiver = transceiver
 
     @overrides(
         AbstractMultiConnectionProcessConnectionSelector.get_next_connection)
@@ -40,3 +42,9 @@ class RoundRobinConnectionSelector(
         index = self._next_connection_index
         self._next_connection_index = (index + 1) % len(self._connections)
         return self._connections[index]
+    
+    @property
+    @overrides(
+        AbstractMultiConnectionProcessConnectionSelector.transceiver)
+    def transceiver(self):
+        return self._transceiver

--- a/spinnman/processes/round_robin_connection_selector.py
+++ b/spinnman/processes/round_robin_connection_selector.py
@@ -27,7 +27,7 @@ class RoundRobinConnectionSelector(
         "_next_connection_index",
         "_transceiver"]
 
-    def __init__(self, connections, transceiver):  # pylint: disable=super-init-not-called
+    def __init__(self, connections, transceiver):
         """
         :param list(SCAMPConnection) connections:
             The connections to be used
@@ -42,7 +42,7 @@ class RoundRobinConnectionSelector(
         index = self._next_connection_index
         self._next_connection_index = (index + 1) % len(self._connections)
         return self._connections[index]
-    
+
     @property
     @overrides(
         AbstractMultiConnectionProcessConnectionSelector.transceiver)

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -376,7 +376,7 @@ class Transceiver(AbstractContextManager):
                 if isinstance(conn, BMPConnection):
                     self._bmp_connections.append(conn)
                     self._bmp_connection_selectors[conn.cabinet, conn.frame] =\
-                        MostDirectConnectionSelector(None, [conn])
+                        MostDirectConnectionSelector(None, [conn], self)
                 else:
                     self._scamp_connections.append(conn)
 
@@ -387,7 +387,7 @@ class Transceiver(AbstractContextManager):
 
         # update the transceiver with the conn selectors.
         return MostDirectConnectionSelector(
-            self._machine, self._scamp_connections)
+            self._machine, self._scamp_connections, self)
 
     def _check_bmp_connections(self):
         """ Check that the BMP connections are actually connected to valid BMPs
@@ -600,7 +600,7 @@ class Transceiver(AbstractContextManager):
 
         # check if it works
         if self._check_connection(
-                MostDirectConnectionSelector(None, [conn]), x, y):
+                MostDirectConnectionSelector(None, [conn], self), x, y):
             self._scp_sender_connections.append(conn)
             self._all_connections.add(conn)
             self._udp_scamp_connections[ip_address] = conn
@@ -652,7 +652,7 @@ class Transceiver(AbstractContextManager):
             logger.info(ip_address)
             self._check_and_add_scamp_connections(x, y, ip_address)
         self._scamp_connection_selector = MostDirectConnectionSelector(
-            self._machine, self._scamp_connections)
+            self._machine, self._scamp_connections, self)
 
     def add_scamp_connections(self, connections):
         """
@@ -674,7 +674,7 @@ class Transceiver(AbstractContextManager):
         for ((x, y), ip_address) in connections.items():
             self._check_and_add_scamp_connections(x, y, ip_address)
         self._scamp_connection_selector = MostDirectConnectionSelector(
-            self._machine, self._scamp_connections)
+            self._machine, self._scamp_connections, self)
 
     def get_connections(self):
         """ Get the currently known connections to the board, made up of those\
@@ -2088,8 +2088,8 @@ class Transceiver(AbstractContextManager):
         break_down = "\n"
         for (x, y, p), core_info in cpu_infos.cpu_infos:
             if core_info.state == CPUState.RUN_TIME_EXCEPTION:
-                break_down += "    {}:{}:{} in state {}:{}\n".format(
-                    x, y, p, core_info.state.name,
+                break_down += "    {}:{}:{} (ph: {}) in state {}:{}\n".format(
+                    x, y, p, core_info.physical_cpu_id, core_info.state.name,
                     core_info.run_time_error.name)
                 break_down += "        r0={}, r1={}, r2={}, r3={}\n".format(
                     core_info.registers[0], core_info.registers[1],

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -911,7 +911,7 @@ class Transceiver(AbstractContextManager):
             process.execute(IPTagSetTTO(
                 scamp_connection.chip_x, scamp_connection.chip_y,
                 IPTAG_TIME_OUT_WAIT_TIMES.TIMEOUT_2560_ms))
-        
+
         # Update the connection selector so that it can ask for processor ids
         self._scamp_connection_selector = MostDirectConnectionSelector(
             self._machine, self._scamp_connections, self)

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -376,7 +376,7 @@ class Transceiver(AbstractContextManager):
                 if isinstance(conn, BMPConnection):
                     self._bmp_connections.append(conn)
                     self._bmp_connection_selectors[conn.cabinet, conn.frame] =\
-                        MostDirectConnectionSelector(None, [conn], self)
+                        MostDirectConnectionSelector(None, [conn], None)
                 else:
                     self._scamp_connections.append(conn)
 
@@ -387,7 +387,7 @@ class Transceiver(AbstractContextManager):
 
         # update the transceiver with the conn selectors.
         return MostDirectConnectionSelector(
-            self._machine, self._scamp_connections, self)
+            self._machine, self._scamp_connections, None)
 
     def _check_bmp_connections(self):
         """ Check that the BMP connections are actually connected to valid BMPs
@@ -600,7 +600,7 @@ class Transceiver(AbstractContextManager):
 
         # check if it works
         if self._check_connection(
-                MostDirectConnectionSelector(None, [conn], self), x, y):
+                MostDirectConnectionSelector(None, [conn], None), x, y):
             self._scp_sender_connections.append(conn)
             self._all_connections.add(conn)
             self._udp_scamp_connections[ip_address] = conn
@@ -911,6 +911,10 @@ class Transceiver(AbstractContextManager):
             process.execute(IPTagSetTTO(
                 scamp_connection.chip_x, scamp_connection.chip_y,
                 IPTAG_TIME_OUT_WAIT_TIMES.TIMEOUT_2560_ms))
+        
+        # Update the connection selector so that it can ask for processor ids
+        self._scamp_connection_selector = MostDirectConnectionSelector(
+            self._machine, self._scamp_connections, self)
 
         return version_info
 

--- a/unittests/model_tests/test_abstract_process.py
+++ b/unittests/model_tests/test_abstract_process.py
@@ -44,6 +44,6 @@ class MockConnection(SCAMPConnection):
 def test_error_print():
     unittest_setup()
     connection = MockConnection(0, 0)
-    process = MockProcess(RoundRobinConnectionSelector([connection]))
+    process = MockProcess(RoundRobinConnectionSelector([connection], None))
     with pytest.raises(SpinnmanGenericProcessException):
         process.test()


### PR DESCRIPTION
Related to board testing in SpiNNakerManchester/sPyNNaker#1151, this enables the display of physical core identifiers where possible.  Note SpiNNakerManchester/SpiNNFrontEndCommon#923 has been updated to take more advantage of this (and remove some duplicated code).