### PR TITLE
removed BootPortNum as always None

### DIFF
--- a/spinnman/connections/udp_packet_connections/boot_connection.py
+++ b/spinnman/connections/udp_packet_connections/boot_connection.py
@@ -33,29 +33,17 @@ class BootConnection(
         "BootConnection(local_host={}, local_port={}, remote_host={}, "
         "remote_port={})")
 
-    def __init__(self, local_host=None, local_port=None, remote_host=None,
-                 remote_port=None):
+    def __init__(self, remote_host=None):
         """
-        :param str local_host:
-            The local host name or IP address to bind to.
-            If not specified defaults to bind to all interfaces, unless
-            `remote_host` is specified, in which case binding is done to the
-            IP address that will be used to send packets.
-        :param int local_port:
-            The local port to bind to, between 1025 and 65535.
-            If not specified, defaults to a random unused local port
         :param str remote_host:
             The remote host name or IP address to send packets to.  If not
             specified, the socket will be available for listening only, and
             will throw and exception if used for sending
-        :param int remote_port: The remote port to send packets to.  If
-            `remote_host` is None, this is ignored.
         :raise SpinnmanIOException:
             If there is an error setting up the communication channel
         """
-        if remote_port is None:
-            remote_port = UDP_BOOT_CONNECTION_DEFAULT_PORT
-        super().__init__(local_host, local_port, remote_host, remote_port)
+        super().__init__(remote_host=remote_host,
+                         remote_port=UDP_BOOT_CONNECTION_DEFAULT_PORT)
 
     @overrides(SpinnakerBootSender.send_boot_message)
     def send_boot_message(self, boot_message):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -96,8 +96,7 @@ _EXECUTABLE_ADDRESS = 0x67800000
 
 def create_transceiver_from_hostname(
         hostname, version, bmp_connection_data=None, number_of_boards=None,
-        auto_detect_bmp=False, boot_port_no=None,
-        default_report_directory=None):
+        auto_detect_bmp=False, default_report_directory=None):
     """ Create a Transceiver by creating a :py:class:`~.UDPConnection` to the\
         given hostname on port 17893 (the default SCAMP port), and a\
         :py:class:`~.BootConnection` on port 54321 (the default boot port),\
@@ -117,7 +116,6 @@ def create_transceiver_from_hostname(
     :param bool auto_detect_bmp:
         ``True`` if the BMP of version 4 or 5 boards should be
         automatically determined from the board IP address
-    :param int boot_port_no: the port number used to boot the machine
     :param scamp_connections:
         the list of connections used for SCAMP communications
     :param default_report_directory:
@@ -159,8 +157,7 @@ def create_transceiver_from_hostname(
     connections.append(SCAMPConnection(remote_host=hostname))
 
     # handle the boot connection
-    connections.append(BootConnection(
-        remote_host=hostname, remote_port=boot_port_no))
+    connections.append(BootConnection(remote_host=hostname))
 
     return Transceiver(
         version, connections=connections,


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/831

BootPortNum is Always None so can be removed.

Must be doe at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/934

