### PR TITLE
Stop producing quite so many logging messages during testing

### DIFF
--- a/spinnman/connections/connection_listener.py
+++ b/spinnman/connections/connection_listener.py
@@ -18,6 +18,7 @@ from threading import Thread
 from concurrent.futures import ThreadPoolExecutor
 from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.log import FormatAdapter
+from spinnman.exceptions import SpinnmanEOFException
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _POOL_SIZE = 4
@@ -80,6 +81,8 @@ class ConnectionListener(Thread, AbstractContextManager):
             while not self.__done:
                 try:
                     self.__run_step(handler)
+                except SpinnmanEOFException:
+                    self.__done = True
                 except Exception:  # pylint: disable=broad-except
                     if not self.__done:
                         logger.warning("problem when dispatching message",

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -142,6 +142,16 @@ class SpinnmanIOException(SpinnmanException):
         return self._problem
 
 
+class SpinnmanEOFException(SpinnmanIOException):
+    """
+    An exception that we're trying to do I/O on a closed socket.
+    That isn't going to work!
+    """
+
+    def __init__(self):
+        super().__init__("connection is closed")
+
+
 class SpinnmanTimeoutException(SpinnmanException):
     """ An exception that indicates that a timeout occurred before an operation
         could finish


### PR DESCRIPTION
This makes closed sockets give much less obscure errors too. Complaints about a negative file descriptor are singularly unhelpful (obscure, etc.) whereas saying that a socket is closed is a lot clearer. That in turn helps the connection listener thread behave more sensibly in the situation, which is what clears up a lot of error messages.

That this requires looking at the `_closed` property of sockets is a bit nasty. We could reproduce that ourselves, but that'd just give an opportunity for things to go out of synch.