### PR TITLE
No P2PC command

### DIFF
--- a/spinnman/messages/scp/enums/scp_command.py
+++ b/spinnman/messages/scp/enums/scp_command.py
@@ -30,7 +30,6 @@ class SCPCommand(Enum):
     CMD_LINK_WRITE = (18, "Write neighbouring chip's memory.")
     CMD_AR = 19
     CMD_NNP = (20, "Send a Nearest-Neighbour packet")
-    CMD_P2PC = 21
     CMD_SIG = (22, "Send a Signal")
     CMD_FFD = (23, "Send Flood-Fill Data")
     CMD_AS = 24

--- a/unittests/scp_tests/test_scp_enums.py
+++ b/unittests/scp_tests/test_scp_enums.py
@@ -48,7 +48,6 @@ class TestSCPEnums(unittest.TestCase):
         self.assertEqual(SCPCommand.CMD_AR.value, 19)
 
         self.assertEqual(SCPCommand.CMD_NNP.value, 20)
-        self.assertEqual(SCPCommand.CMD_P2PC.value, 21)
         self.assertEqual(SCPCommand.CMD_SIG.value, 22)
         self.assertEqual(SCPCommand.CMD_FFD.value, 23)
         self.assertEqual(SCPCommand.CMD_AS.value, 24)


### PR DESCRIPTION
The infrastructure to support `CMD_P2PC` was removed 6 years ago. Nuke the tooling that could try to reach it anyway.