### PR TITLE
More error details

### DIFF
--- a/spinnman/connections/scp_request_pipeline.py
+++ b/spinnman/connections/scp_request_pipeline.py
@@ -285,7 +285,7 @@ class SCPRequestPipeLine(object):
             raise SpinnmanIOException(
                 "Errors sending request {} to {}, {}, {} over {} retries: {}"
                 .format(
-                    request_sent.scp_request_header.command,
+                    request_sent,
                     request_sent.sdp_header.destination_chip_x,
                     request_sent.sdp_header.destination_chip_y,
                     request_sent.sdp_header.destination_cpu,

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -240,7 +240,7 @@ class _Group(object):
         self.chip_core += "]"
 
     def add_coord(self, sdp_header, phys_p):
-        self.chip_core += "{}[{}:{}:{}({})]".format(
+        self.chip_core += "{}[{}:{}:{}{}]".format(
             self._separator,
             sdp_header.destination_chip_x,
             sdp_header.destination_chip_y,

--- a/spinnman/exceptions.py
+++ b/spinnman/exceptions.py
@@ -286,17 +286,23 @@ class SpinnmanGroupedProcessException(SpinnmanException):
     def __init__(self, error_requests, exceptions, tracebacks, connections,
                  machine):
         problem = "Exceptions found were:\n"
-        for exception, description in _Group.group_exceptions(
-                error_requests, exceptions, tracebacks, connections,
-                machine):
+        for error_request, exception, trace_back, connection in zip(
+                error_requests, exceptions, tracebacks, connections):
+            sdp_header = error_request.sdp_header
+            phys_p = get_physical_cpu_id(machine, sdp_header)
+            location = "board {} with ethernet chip {}:{} [{}:{}:{}{}]".format(
+                connection.remote_ip_address, connection.chip_x,
+                connection.chip_y, sdp_header.destination_chip_x,
+                sdp_header.destination_chip_y,
+                sdp_header.destination_cpu, phys_p)
             problem += \
                 "   Received exception class: {}\n" \
                 "       With message {}\n" \
                 "       When sending to {}\n" \
                 "       Stack trace: {}\n".format(
                     exception.__class__.__name__, str(exception),
-                    description.chip_core,
-                    traceback.format_tb(description.trace_back))
+                    location,
+                    traceback.format_tb(trace_back))
         super().__init__(problem)
 
 

--- a/spinnman/messages/scp/abstract_messages/scp_request.py
+++ b/spinnman/messages/scp/abstract_messages/scp_request.py
@@ -121,6 +121,13 @@ class AbstractSCPRequest(object, metaclass=AbstractBase):
             data += bytes(self._data)
         return data
 
+    def __repr__(self):
+        # Default is to return just the command, but can be overridden
+        return str(self._scp_request_header.command)
+
+    def __str__(self):
+        return self.__repr__()
+
     @abstractmethod
     def get_scp_response(self):
         """ Get an SCP response message to be used to process any response\

--- a/spinnman/messages/scp/impl/app_copy_run.py
+++ b/spinnman/messages/scp/impl/app_copy_run.py
@@ -65,6 +65,9 @@ class AppCopyRun(AbstractSCPRequest):
             SCPRequestHeader(command=SCPCommand.CMD_APP_COPY_RUN),
             argument_1=link, argument_2=size, argument_3=processor_mask)
 
+    def __repr__(self):
+        return f"{super(AppCopyRun, self).__repr__()} (Link {self.__link})"
+
     @overrides(AbstractSCPRequest.get_scp_response)
     def get_scp_response(self):
         return CheckOKResponse(

--- a/spinnman/messages/scp/impl/app_copy_run.py
+++ b/spinnman/messages/scp/impl/app_copy_run.py
@@ -28,7 +28,7 @@ _WAIT_FLAG = 0x1 << 18
 class AppCopyRun(AbstractSCPRequest):
     """ An SCP request to copy an application and start it
     """
-    __slots__ = []
+    __slots__ = ["__link"]
 
     def __init__(self, x, y, link, size, app_id, processors, wait=False):
         """
@@ -55,6 +55,7 @@ class AppCopyRun(AbstractSCPRequest):
         processor_mask |= (app_id << 24)
         if wait:
             processor_mask |= _WAIT_FLAG
+        self.__link = link
 
         super().__init__(
             SDPHeader(
@@ -67,4 +68,5 @@ class AppCopyRun(AbstractSCPRequest):
     @overrides(AbstractSCPRequest.get_scp_response)
     def get_scp_response(self):
         return CheckOKResponse(
-            "Application Copy Run", SCPCommand.CMD_APP_COPY_RUN)
+            f"Application Copy Run (Link {self.__link})",
+            SCPCommand.CMD_APP_COPY_RUN)


### PR DESCRIPTION
Simple change to allow link to be shown when an error happens, so that it can be checked and blacklisted if needed.  Also removes brackets from an error since the brackets are already included elsewhere (as is the space).