### PR TITLE
Fix copy run 0 0

### DIFF
--- a/spinnman/processes/application_copy_run_process.py
+++ b/spinnman/processes/application_copy_run_process.py
@@ -66,7 +66,7 @@ class ApplicationCopyRunProcess(AbstractMultiConnectionProcess):
             Whether to put the binary in "wait" mode or run it straight away
         """
         boot_chip = machine.boot_chip
-        chips_done = set((boot_chip.x, boot_chip.y))
+        chips_done = set([(boot_chip.x, boot_chip.y)])
         next_chips = _get_next_chips([(None, boot_chip)], machine, chips_done)
 
         while next_chips:

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -2112,7 +2112,7 @@ class Transceiver(AbstractContextManager):
                 break_down += "        r4={}, r5={}, r6={}, r7={}\n".format(
                     core_info.registers[4], core_info.registers[5],
                     core_info.registers[6], core_info.registers[7])
-                break_down += "        PSR={}, SP={}, LR={}".format(
+                break_down += "        PSR={}, SP={}, LR={}\n".format(
                     core_info.processor_state_register,
                     core_info.stack_pointer, core_info.link_register)
             else:


### PR DESCRIPTION
Fixes the issue that on some boards copy run would re-do the write on 0, 0 (and also sneaks in a fix to the error message by adding an extra \n)