### PR TITLE
More basic network utils

### DIFF
--- a/spinnman/connections/udp_packet_connections/bmp_connection.py
+++ b/spinnman/connections/udp_packet_connections/bmp_connection.py
@@ -16,10 +16,10 @@
 import struct
 from spinn_utilities.overrides import overrides
 from .udp_connection import UDPConnection
-from .utils import update_sdp_header_for_udp_send
 from spinnman.constants import SCP_SCAMP_PORT
 from spinnman.messages.scp.enums import SCPResult
 from spinnman.connections.abstract_classes import SCPReceiver, SCPSender
+from .utils import update_sdp_header_for_udp_send
 
 _TWO_SHORTS = struct.Struct("<2H")
 _TWO_SKIP = struct.Struct("<2x")

--- a/spinnman/connections/udp_packet_connections/scamp_connection.py
+++ b/spinnman/connections/udp_packet_connections/scamp_connection.py
@@ -16,8 +16,8 @@
 import struct
 from spinnman.constants import SCP_SCAMP_PORT
 from spinnman.messages.scp.enums import SCPResult
-from .utils import update_sdp_header_for_udp_send
 from .sdp_connection import SDPConnection
+from .utils import update_sdp_header_for_udp_send
 from spinnman.connections.abstract_classes import SCPSender, SCPReceiver
 from spinn_utilities.overrides import overrides
 

--- a/spinnman/connections/udp_packet_connections/udp_connection.py
+++ b/spinnman/connections/udp_packet_connections/udp_connection.py
@@ -19,11 +19,12 @@ import select
 from contextlib import suppress
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
+from spinn_utilities.ping import Ping
 from spinnman.exceptions import (
     SpinnmanIOException, SpinnmanTimeoutException, SpinnmanEOFException)
 from spinnman.connections.abstract_classes import Connection
-from .utils import (
-    bind_socket, connect_socket, get_socket, get_socket_address, ping,
+from spinnman.utilities.socket_utils import (
+    bind_socket, connect_socket, get_udp_socket, get_socket_address,
     resolve_host, set_receive_buffer_size)
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -61,7 +62,7 @@ class UDPConnection(Connection):
             If there is an error setting up the communication channel
         """
 
-        self._socket = get_socket()
+        self._socket = get_udp_socket()
         set_receive_buffer_size(self._socket, _RECEIVE_BUFFER_SIZE)
 
         # Get the host and port to bind to locally
@@ -119,7 +120,7 @@ class UDPConnection(Connection):
         # check if machine is active and on the network
         for _ in range(_PING_COUNT):
             # Assume connected if ping works
-            if ping(self._remote_ip_address).returncode == 0:
+            if Ping.ping(self._remote_ip_address) == 0:
                 return True
 
         # If the ping fails this number of times, the host cannot be contacted

--- a/spinnman/connections/udp_packet_connections/utils.py
+++ b/spinnman/connections/udp_packet_connections/utils.py
@@ -40,11 +40,25 @@ def update_sdp_header_for_udp_send(sdp_header, source_x, source_y):
 
 
 def get_socket():
-    """ Wrapper round socket() system call.
+    """ Wrapper round socket() system call to produce UDP/IPv4 sockets.
     """
     try:
         # Create a UDP Socket
         return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error setting up socket: {}".format(exception)) from exception
+
+
+def get_tcp_socket():
+    """ Wrapper round socket() system call to produce TCP/IPv4 sockets.
+
+    .. note::
+        TCP sockets cannot be used to talk to a SpiNNaker board.
+    """
+    try:
+        # Create a UDP Socket
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     except Exception as exception:  # pylint: disable=broad-except
         raise SpinnmanIOException(
             "Error setting up socket: {}".format(exception)) from exception

--- a/spinnman/connections/udp_packet_connections/utils.py
+++ b/spinnman/connections/udp_packet_connections/utils.py
@@ -13,14 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-import platform
-import socket
-import subprocess
-from spinn_utilities.log import FormatAdapter
-from spinnman.exceptions import SpinnmanIOException
-
-logger = FormatAdapter(logging.getLogger(__name__))
 _SDP_SOURCE_PORT = 7
 _SDP_SOURCE_CPU = 31
 _SDP_TAG = 0xFF
@@ -30,106 +22,9 @@ def update_sdp_header_for_udp_send(sdp_header, source_x, source_y):
     """ Apply defaults to the SDP header for sending over UDP
 
     :param SDPHeader sdp_header: The SDP header values
-    :return: Nothing is returned
     """
     sdp_header.tag = _SDP_TAG
     sdp_header.source_port = _SDP_SOURCE_PORT
     sdp_header.source_cpu = _SDP_SOURCE_CPU
     sdp_header.source_chip_x = source_x
     sdp_header.source_chip_y = source_y
-
-
-def get_socket():
-    """ Wrapper round socket() system call to produce UDP/IPv4 sockets.
-    """
-    try:
-        # Create a UDP Socket
-        return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException(
-            "Error setting up socket: {}".format(exception)) from exception
-
-
-def get_tcp_socket():
-    """ Wrapper round socket() system call to produce TCP/IPv4 sockets.
-
-    .. note::
-        TCP sockets cannot be used to talk to a SpiNNaker board.
-    """
-    try:
-        # Create a UDP Socket
-        return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException(
-            "Error setting up socket: {}".format(exception)) from exception
-
-
-def set_receive_buffer_size(sock, size):
-    """ Wrapper round setsockopt() system call.
-    """
-    try:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, size)
-    except Exception:  # pylint: disable=broad-except
-        # The OS said no, but we might still be able to work right with
-        # the defaults. Just warn and hope...
-        logger.warning("failed to configure UDP socket to have a large "
-                       "receive buffer", exc_info=True)
-
-
-def bind_socket(sock, host, port):
-    """ Wrapper round bind() system call.
-    """
-    try:
-        # Bind the socket
-        sock.bind((str(host), int(port)))
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException(
-            "Error binding socket to {}:{}: {}".format(
-                host, port, exception)) from exception
-
-
-def resolve_host(host):
-    """ Wrapper round gethostbyname() system call.
-    """
-    try:
-        return socket.gethostbyname(host)
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException(
-            "Error getting IP address for {}: {}".format(
-                host, exception)) from exception
-
-
-def connect_socket(sock, remote_address, remote_port):
-    """ Wrapper round connect() system call.
-    """
-    try:
-        sock.connect((str(remote_address), int(remote_port)))
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException(
-            "Error connecting to {}:{}: {}".format(
-                remote_address, remote_port, exception)) from exception
-
-
-def get_socket_address(sock):
-    """ Wrapper round getsockname() system call.
-    """
-    try:
-        addr, port = sock.getsockname()
-        # Ensure that a standard address is used for the INADDR_ANY
-        # hostname
-        if addr is None or addr == "":
-            addr = "0.0.0.0"
-        return addr, port
-    except Exception as exception:  # pylint: disable=broad-except
-        raise SpinnmanIOException("Error querying socket: {}".format(
-            exception)) from exception
-
-
-def ping(address):
-    if platform.platform().lower().startswith("windows"):
-        cmd = "ping -n 1 -w 1 " + address
-    else:
-        cmd = "ping -c 1 -W 1 " + address
-    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    process.wait()
-    return process

--- a/spinnman/utilities/socket_utils.py
+++ b/spinnman/utilities/socket_utils.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import socket
+from spinn_utilities.log import FormatAdapter
+from spinnman.exceptions import SpinnmanIOException
+
+logger = FormatAdapter(logging.getLogger(__name__))
+
+
+def get_udp_socket():
+    """ Wrapper round socket() system call to produce UDP/IPv4 sockets.
+    """
+    try:
+        # Create a UDP Socket
+        return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error setting up socket: {}".format(exception)) from exception
+
+
+def get_tcp_socket():
+    """ Wrapper round socket() system call to produce TCP/IPv4 sockets.
+
+    .. note::
+        TCP sockets cannot be used to talk to a SpiNNaker board.
+    """
+    try:
+        # Create a UDP Socket
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error setting up socket: {}".format(exception)) from exception
+
+
+def set_receive_buffer_size(sock, size):
+    """ Wrapper round setsockopt() system call.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, size)
+    except Exception:  # pylint: disable=broad-except
+        # The OS said no, but we might still be able to work right with
+        # the defaults. Just warn and hope...
+        logger.warning("failed to configure UDP socket to have a large "
+                       "receive buffer", exc_info=True)
+
+
+def bind_socket(sock, host, port):
+    """ Wrapper round bind() system call.
+    """
+    try:
+        # Bind the socket
+        sock.bind((str(host), int(port)))
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error binding socket to {}:{}: {}".format(
+                host, port, exception)) from exception
+
+
+def resolve_host(host):
+    """ Wrapper round gethostbyname() system call.
+    """
+    try:
+        return socket.gethostbyname(host)
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error getting IP address for {}: {}".format(
+                host, exception)) from exception
+
+
+def connect_socket(sock, remote_address, remote_port):
+    """ Wrapper round connect() system call.
+    """
+    try:
+        sock.connect((str(remote_address), int(remote_port)))
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException(
+            "Error connecting to {}:{}: {}".format(
+                remote_address, remote_port, exception)) from exception
+
+
+def get_socket_address(sock):
+    """ Wrapper round getsockname() system call.
+    """
+    try:
+        addr, port = sock.getsockname()
+        # Ensure that a standard address is used for the INADDR_ANY
+        # hostname
+        if addr is None or addr == "":
+            addr = "0.0.0.0"
+        return addr, port
+    except Exception as exception:  # pylint: disable=broad-except
+        raise SpinnmanIOException("Error querying socket: {}".format(
+            exception)) from exception


### PR DESCRIPTION
Add more basic socket utility functions (just wrappers around the basic calls to make the exceptions nicer) and move them to a better location. I leave `update_sdp_header_for_udp_send` where it is because it is used by FEC and is a different kind of utility call; it didn't ever really belong with the others.

Also stop keeping a second copy of the ping code around. SpiNNUtils is to be the expert on that.