### PR TITLE
Pylint fix

### DIFF
--- a/spinnman/messages/scp/impl/router_alloc.py
+++ b/spinnman/messages/scp/impl/router_alloc.py
@@ -40,6 +40,7 @@ class RouterAlloc(AbstractSCPRequest):
         :param int app_id: The ID of the application, between 0 and 255
         :param int n_entries: The number of entries to allocate
         """
+        # pylint: disable=unsupported-binary-operation
         super().__init__(
             SDPHeader(
                 flags=SDPFlag.REPLY_EXPECTED, destination_port=0,

--- a/spinnman/messages/scp/impl/sdram_alloc.py
+++ b/spinnman/messages/scp/impl/sdram_alloc.py
@@ -63,6 +63,7 @@ class SDRAMAlloc(AbstractSCPRequest):
                 "The tag param needs to be between 0 and 255, or None (in "
                 "which case 0 will be used by default)", str(tag))
 
+        # pylint: disable=unsupported-binary-operation
         super().__init__(
             SDPHeader(
                 flags=SDPFlag.REPLY_EXPECTED, destination_port=0,

--- a/spinnman/messages/scp/impl/sdram_de_alloc.py
+++ b/spinnman/messages/scp/impl/sdram_de_alloc.py
@@ -42,9 +42,8 @@ class SDRAMDeAlloc(AbstractSCPRequest):
             needs to be deallocated, or none if deallocating via app_id
         :type base_address: int or None
         """
-
+        # pylint: disable=unsupported-binary-operation
         if base_address is not None:
-            # pylint: disable=unsupported-binary-operation
             super().__init__(
                 SDPHeader(
                     flags=SDPFlag.REPLY_EXPECTED, destination_port=0,

--- a/spinnman/messages/scp/impl/sdram_de_alloc.py
+++ b/spinnman/messages/scp/impl/sdram_de_alloc.py
@@ -44,6 +44,7 @@ class SDRAMDeAlloc(AbstractSCPRequest):
         """
 
         if base_address is not None:
+            # pylint: disable=unsupported-binary-operation
             super().__init__(
                 SDPHeader(
                     flags=SDPFlag.REPLY_EXPECTED, destination_port=0,

--- a/spinnman/model/chip_summary_info.py
+++ b/spinnman/model/chip_summary_info.py
@@ -190,6 +190,12 @@ class ChipSummaryInfo(object):
         """
         return self._ethernet_ip_address
 
+    def clear_ethernet_ip_address(self):
+        """ Sets the ethernet_ip_address to None
+
+        """
+        self._ethernet_ip_address = None
+
     @property
     def parent_link(self):
         """ The link to the parent of the chip in the tree of chips from root

--- a/spinnman/processes/get_machine_process.py
+++ b/spinnman/processes/get_machine_process.py
@@ -257,7 +257,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
                         "This ip will not be used.",
                         chip_info.x, chip_info.y,
                         chip_info.ethernet_ip_address)
-                    chip_info._ethernet_ip_address = None
+                    chip_info.clear_ethernet_ip_address()
                 else:
                     logger.warning(
                         "Not using chip {}:{} as it has an unexpected "


### PR DESCRIPTION
fix new unsupported operand type(s) for | (unsupported-binary-operation)

as well as adds a clear_ethernet_ip_address method so an underscore value does not need to be used.