### PR TITLE
push get_status_string into cpuinfos

### DIFF
--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from spinnman.model.enums import CPUState
+
 
 class CPUInfos(object):
     """
@@ -90,6 +92,33 @@ class CPUInfos(object):
         Get the information for the given core on the given chip.
         """
         return self._cpu_infos[x, y, p]
+
+    def get_status_string(self):
+        """
+        Get a string indicating the status of the given cores.
+
+        :param CPUInfos cpu_infos: A CPUInfos objects
+        :rtype: str
+        """
+        break_down = "\n"
+        for (x, y, p), core_info in self.cpu_infos:
+            if core_info.state == CPUState.RUN_TIME_EXCEPTION:
+                break_down += "    {}:{}:{} (ph: {}) in state {}:{}\n".format(
+                    x, y, p, core_info.physical_cpu_id, core_info.state.name,
+                    core_info.run_time_error.name)
+                break_down += "        r0={}, r1={}, r2={}, r3={}\n".format(
+                    core_info.registers[0], core_info.registers[1],
+                    core_info.registers[2], core_info.registers[3])
+                break_down += "        r4={}, r5={}, r6={}, r7={}\n".format(
+                    core_info.registers[4], core_info.registers[5],
+                    core_info.registers[6], core_info.registers[7])
+                break_down += "        PSR={}, SP={}, LR={}\n".format(
+                    core_info.processor_state_register,
+                    core_info.stack_pointer, core_info.link_register)
+            else:
+                break_down += "    {}:{}:{} in state {}\n".format(
+                    x, y, p, core_info.state.name)
+        return break_down
 
     def __str__(self):
         return str([f"{x}, {y}, {p} (ph: {info.physical_cpu_id})"

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -46,6 +46,7 @@ from spinnman.exceptions import (
     SpiNNManCoresNotInStateException)
 from spinnman.model import CPUInfos, DiagnosticFilter, MachineDimensions
 from spinnman.model.enums import CPUState
+from spinnman.messages.scp.enums import Signal
 from spinnman.messages.scp.impl.get_chip_info import GetChipInfo
 from spinnman.messages.spinnaker_boot import (
     SystemVariableDefinition, SpinnakerBootMessages)

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1366,7 +1366,7 @@ class Transceiver(AbstractContextManager):
                 raise SpinnmanException(
                     f"Only {count} of {executable_targets.total_processors} "
                     "cores reached ready state: "
-                    f"{self.get_core_status_string(cores_ready)}")
+                    f"{cores_ready.get_status_string()}")
 
         # Send a signal telling the application to start
         self.send_signal(app_id, Signal.START)
@@ -2101,7 +2101,7 @@ class Transceiver(AbstractContextManager):
         :param states: The state or states to filter on
         :type states: CPUState or set(CPUState)
         :return: Core subsets object containing cores not in the given state(s)
-        :rtype: ~spinn_machine.CoreSubsets
+        :rtype: CPUInfos
         """
         core_infos = self.get_cpu_information(all_core_subsets)
         cores_not_in_state = CPUInfos()
@@ -2114,33 +2114,6 @@ class Transceiver(AbstractContextManager):
                 cores_not_in_state.add_processor(
                     core_info.x, core_info.y, core_info.p, core_info)
         return cores_not_in_state
-
-    def get_core_status_string(self, cpu_infos):
-        """
-        Get a string indicating the status of the given cores.
-
-        :param CPUInfos cpu_infos: A CPUInfos objects
-        :rtype: str
-        """
-        break_down = "\n"
-        for (x, y, p), core_info in cpu_infos.cpu_infos:
-            if core_info.state == CPUState.RUN_TIME_EXCEPTION:
-                break_down += "    {}:{}:{} (ph: {}) in state {}:{}\n".format(
-                    x, y, p, core_info.physical_cpu_id, core_info.state.name,
-                    core_info.run_time_error.name)
-                break_down += "        r0={}, r1={}, r2={}, r3={}\n".format(
-                    core_info.registers[0], core_info.registers[1],
-                    core_info.registers[2], core_info.registers[3])
-                break_down += "        r4={}, r5={}, r6={}, r7={}\n".format(
-                    core_info.registers[4], core_info.registers[5],
-                    core_info.registers[6], core_info.registers[7])
-                break_down += "        PSR={}, SP={}, LR={}\n".format(
-                    core_info.processor_state_register,
-                    core_info.stack_pointer, core_info.link_register)
-            else:
-                break_down += "    {}:{}:{} in state {}\n".format(
-                    x, y, p, core_info.state.name)
-        return break_down
 
     def send_signal(self, app_id, signal):
         """


### PR DESCRIPTION
Method get_core_status_string does not need to be a transceiver method.

Better in the class it actually use.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1076


