### PR TITLE
Hide transceiver

### DIFF
--- a/spinnman/constants.py
+++ b/spinnman/constants.py
@@ -60,14 +60,11 @@ CPU_INFO_BYTES = 128
 #: The address at which user0 register starts
 CPU_USER_0_START_ADDRESS = 112
 
-#: The address at which user1 register starts
-CPU_USER_1_START_ADDRESS = 116
+# The number of bytes the user start address moves each time
+CPU_USER_OFFSET = 4
 
-#: The address at which user2 register starts
-CPU_USER_2_START_ADDRESS = 120
-
-#: The address at which user3 register starts
-CPU_USER_3_START_ADDRESS = 124
+# The largest user number
+CPU_MAX_USER = 3
 
 #: The address at which the iobuf address starts
 CPU_IOBUF_ADDRESS_OFFSET = 88

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -510,6 +510,48 @@ class SpiNNManDataView(MachineDataView):
             raise
 
     @classmethod
+    def write_router_diagnostic_filter(
+            cls, x, y, position, diagnostic_filter):
+        """
+        Sets a router diagnostic filter in a router.
+
+        Syntactic sugar for `get_transceiver().set_router_diagnostic_filter`.
+
+        :param int x:
+            The X address of the router in which this filter is being set.
+        :param int y:
+            The Y address of the router in which this filter is being set.
+        :param int position:
+            The position in the list of filters where this filter is to be
+            added.
+        :param DiagnosticFilter diagnostic_filter:
+            The diagnostic filter being set in the placed, between 0 and 15.
+
+            .. note::
+                Positions 0 to 11 are used by the default filters,
+                and setting these positions will result in a warning.
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            * If there is an error communicating with the board
+            * If there is an error reading the data
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If x, y does not lead to a valid chip
+            * If position is less than 0 or more than 15
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.set_router_diagnostic_filter(
+                x, y, position, diagnostic_filter)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
     def write_signal(cls, app_id, signal):
         """
         Writes/ Sends a signal to an application.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -188,6 +188,39 @@ class SpiNNManDataView(MachineDataView):
            raise
 
     @classmethod
+    def read_iobuf(cls, core_subsets=None):
+        """
+        Get the contents of the IOBUF buffer for a number of processors.
+
+        Syntactic sugar for `get_transceiver().read_iobuf`.
+
+        :param ~spinn_machine.CoreSubsets core_subsets:
+            A set of chips and cores from which to get the buffers. If not
+            specified, the buffers from all of the cores on all of the chips
+            on the board are obtained.
+        :return: An iterable of the buffers, which may not be in the order
+            of core_subsets
+        :rtype: iterable(IOBuffer)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If chip_and_cores contains invalid items
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.read_iobuf(core_subsets)
+        except AttributeError as ex:
+           if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+           raise
+
+    @classmethod
     def read_memory(cls, x, y, base_address, length, cpu=0):
         """
         Read some areas of memory (usually SDRAM) from the board.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -388,6 +388,8 @@ class SpiNNManDataView(MachineDataView):
         Waits for the specified cores running the given application to be
         in some target state or states. Handles failures.
 
+        Syntactic sugar for `get_transceiver().wait_for_cores_to_be_in_state`.
+
         :param ~spinn_machine.CoreSubsets all_core_subsets:
             the cores to check are in a given sync state
         :param int app_id: the application ID that being used by the simulation
@@ -421,8 +423,13 @@ class SpiNNManDataView(MachineDataView):
         """
         Clear router diagnostic information on a chip.
 
+        Syntactic sugar for
+        `get_transceiver().clear_router_diagnostic_counters`.
+
         :param int x: The x-coordinate of the chip
         :param int y: The y-coordinate of the chip
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
         :raise SpinnmanIOException:
             If there is an error communicating with the board
         :raise SpinnmanInvalidPacketException:
@@ -436,6 +443,30 @@ class SpiNNManDataView(MachineDataView):
         if cls.__data._transceiver is None:
             raise cls._exception("transceiver")
         return cls.__data._transceiver.clear_router_diagnostic_counters(x, y)
+
+    @classmethod
+    def malloc_sdram(cls, x, y, size, app_id, tag=None):
+        """
+        Allocates a chunk of SDRAM on a chip on the machine.
+
+        Syntactic sugar for `get_transceiver().malloc_sdram`.
+
+        :param int x: The x-coordinate of the chip onto which to ask for memory
+        :param int y: The y-coordinate of the chip onto which to ask for memory
+        :param int size: the amount of memory to allocate in bytes
+        :param int app_id: The ID of the application with which to associate
+            the routes.  If not specified, defaults to 0.
+        :param int tag: the tag for the SDRAM, a 8-bit (chip-wide) tag that can
+            be looked up by a SpiNNaker application to discover the address of
+            the allocated block. If `0` then no tag is applied.
+        :return: the base address of the allocated memory
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.malloc_sdram(x, y, size, app_id, tag)
 
     # app_id methods
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -123,6 +123,26 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver
 
     @classmethod
+    def read_clock_drift(cls, x, y):
+        """
+        Get the clock drift
+
+        Syntactic sugar for `get_transceiver().get_core_state_count`.
+
+        :param int x: The x-coordinate of the chip to get drift for
+        :param int y: The y-coordinate of the chip to get drift for
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        """
+        try:
+            return cls.__data._transceiver.get_clock_drift(x, y)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+
     def read_core_state_count(cls, app_id, state):
         """
         Get a count of the number of cores which have a given state.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -369,7 +369,7 @@ class SpiNNManDataView(MachineDataView):
                raise
 
     @classmethod
-    def read_tags(cls, connection=None):
+    def read_core_tags(cls, connection=None):
         """
         Get the current set of tags that have been set on the board.
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -651,6 +651,26 @@ class SpiNNManDataView(MachineDataView):
             raise
 
     @classmethod
+    def write_sdp_message(cls, message, connection=None):
+        """
+        Sends an SDP message using one of the connections.
+
+        Syntactic sugar for `get_transceiver().send_sdp_messag`.
+
+        :param SDPMessage message: The message to send
+        :param SDPConnection connection: An optional connection to use
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        """
+        try:
+            return cls.__data._transceiver.send_sdp_message(
+                message, connection)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
     def write_reverse_ip_tag(cls, reverse_ip_tag):
         """
         Set up a reverse IP tag.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -123,11 +123,42 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver
 
     @classmethod
-    def get_cpu_information_from_core(cls, x, y, p):
+    def read_core_state_count(cls, app_id, state):
+        """
+        Get a count of the number of cores which have a given state.
+
+        Syntactic sugar for `get_transceiver().get_core_state_count`.
+
+        :param int app_id:
+            The ID of the application from which to get the count.
+        :param CPUState state: The state count to get
+        :return: A count of the cores with the given status
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If state is not a valid status
+            * If app_id is not a valid application ID
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_core_state_count(app_id, state)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
+    def read_cpu_information_from_core(cls, x, y, p):
         """
         Get information about a specific processor on the board.
 
-        Syntactic sugar for `get_transceiver().read_memory()`.
+        Syntactic sugar for
+        `get_transceiver().get_cpu_information_from_core()`.
 
         :param int x: The x-coordinate of the chip containing the processor
         :param int y: The y-coordinate of the chip containing the processor
@@ -195,6 +226,7 @@ class SpiNNManDataView(MachineDataView):
         Read a word (usually of SDRAM) from the board.
 
         Syntactic sugar for `get_transceiver().read_word()`.
+
         :param int x:
             The x-coordinate of the chip where the word is to be read from
         :param int y:

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -123,6 +123,36 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver
 
     @classmethod
+    def get_cpu_information_from_core(cls, x, y, p):
+        """
+        Get information about a specific processor on the board.
+
+        Syntactic sugar for `get_transceiver().read_memory()`.
+
+        :param int x: The x-coordinate of the chip containing the processor
+        :param int y: The y-coordinate of the chip containing the processor
+        :param int p: The ID of the processor to get the information about
+        :return: The CPU information for the selected core
+        :rtype: CPUInfo
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If x, y, p is not a valid processor
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_cpu_information_from_core(
+                x, y, p)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def read_memory(cls, x, y, base_address, length, cpu=0):
         """
         Read some areas of memory (usually SDRAM) from the board.
@@ -156,6 +186,41 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.read_memory(
                 x, y, base_address, length, cpu)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
+    def read_word(cls, x, y, base_address, cpu=0):
+        """
+        Read a word (usually of SDRAM) from the board.
+
+        Syntactic sugar for `get_transceiver().read_word()`.
+        :param int x:
+            The x-coordinate of the chip where the word is to be read from
+        :param int y:
+            The y-coordinate of the chip where the word is to be read from
+        :param int base_address:
+            The address (usually in SDRAM) where the word to be read starts
+        :param int cpu:
+            the core ID used to read the word; should usually be 0 when reading
+            from SDRAM, but may be other values when reading from DTCM.
+        :return: The unsigned integer value at ``base_address``
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If one of `x`, `y`, `cpu` or `base_address` is invalid
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.read_word(
+                x, y, base_address, cpu)
         except AttributeError as ex:
             raise cls._exception("transceiver") from ex
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -521,6 +521,24 @@ class SpiNNManDataView(MachineDataView):
            raise
 
     @classmethod
+    def write_control_sync(cls, do_sync):
+        """
+        Control the synchronisation of the chips.
+
+        Syntactic sugar for `get_transceiver().read_user`.
+
+        :param bool do_sync: Whether to synchronise or not
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        """
+        try:
+            return cls.__data._transceiver.control_sync(do_sync)
+        except AttributeError as ex:
+           if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+           raise
+
+    @classmethod
     def write_fixed_route(cls, x, y, fixed_route, app_id):
         """
         Loads a fixed route routing table entry onto a chip's router.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -221,6 +221,38 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
+    def write_multicast_routes(cls, x, y, app_id=None):
+        """
+        Get the current multicast routes set up on a chip.
+
+        Syntactic sugar for `get_transceiver().get_multicast_routes`.
+
+        :param int x:
+            The x-coordinate of the chip from which to get the routes
+        :param int y:
+            The y-coordinate of the chip from which to get the routes
+        :param int app_id:
+            The ID of the application to filter the routes for. If
+            not specified, will return all routes
+        :return: An iterable of multicast routes
+        :rtype: list(~spinn_machine.MulticastRoutingEntry)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_multicast_routes(x, y, app_id)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def read_word(cls, x, y, base_address, cpu=0):
         """
         Read a word (usually of SDRAM) from the board.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -312,6 +312,21 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver.write_memory(
             x, y, base_address, data, n_bytes, offset, cpu, is_filename)
 
+    @classmethod
+    def update_provenance_and_exit(cls, processor, core_subset):
+        """
+        Sends a command to update prevenance and exit
+
+        Syntactic sugar for `get_transceiver().update_provenance_and_exit`.
+
+        :param int processor:
+        :param ~.CoreSubset core_subset:
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.update_provenance_and_exit(
+            processor, core_subset)
+
     # app_id methods
 
     @classmethod

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -505,7 +505,7 @@ class SpiNNManDataView(MachineDataView):
         except AttributeError as ex:
             if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-        raise
+            raise
 
     @classmethod
     def write_control_sync(cls, do_sync):

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -110,19 +110,6 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver is not None
 
     @classmethod
-    def get_transceiver(cls):
-        """
-        The transceiver description.
-
-        :rtype: ~spinnman.transceiver.Transceiver
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the transceiver is currently unavailable
-        """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver
-
-    @classmethod
     def read_clock_drift(cls, x, y):
         """
         Get the clock drift

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -142,7 +142,7 @@ class SpiNNManDataView(MachineDataView):
                 raise cls._exception("transceiver") from ex
             raise
 
-
+    @classmethod
     def read_core_state_count(cls, app_id, state):
         """
         Get a count of the number of cores which have a given state.
@@ -202,6 +202,29 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_cpu_information_from_core(
                 x, y, p)
+        except AttributeError as ex:
+           if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+           raise
+
+    @classmethod
+    def read_fixed_route(cls, x, y, app_id):
+        """
+        Reads a fixed route routing table entry from a chip's router.
+
+        Syntactic sugar for `get_transceiver().read_fixed_route`.
+
+        :param int x:
+            The x-coordinate of the chip onto which to load the routes
+        :param int y:
+            The y-coordinate of the chip onto which to load the routes
+        :param int app_id:
+            The ID of the application with which to associate the
+            routes.  If not specified, defaults to 0.
+        :return: the route as a fixed route entry
+        """
+        try:
+            return cls.__data._transceiver.read_fixed_route(x, y, app_id)
         except AttributeError as ex:
            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -279,6 +279,38 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
+    def read_user(cls, user, x, y, p):
+        """
+        Get the contents of this user register for the given processor.
+
+        Syntactic sugar for `get_transceiver().read_user`.
+
+        .. note::
+            Conventionally, user_0 usually holds the address of the table of
+            memory regions.
+
+        :param int user: The user number to get the address for
+        :param int x: X coordinate of the chip
+        :param int y: Y coordinate of the chip
+        :param int p: Virtual processor identifier on the chip
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If x, y, p does not identify a valid processor
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.read_user(user, x, y, p)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def write_memory(cls, x, y, base_address, data, n_bytes=None, offset=0,
                      cpu=0, is_filename=False):
         """
@@ -379,6 +411,37 @@ class SpiNNManDataView(MachineDataView):
         if cls.__data._transceiver is None:
             raise cls._exception("transceiver")
         return cls.__data._transceiver.update_provenance_and_exit(x, y, p)
+
+    @classmethod
+    def write_user(cls, user, x, y, p, value):
+        """
+        Write to this user register for the given processor.
+
+        Syntactic sugar for `get_transceiver().write_user`.
+
+        .. note::
+            Conventionally, user_0 usually holds the address of the table of
+            memory regions.
+
+        :param int user: The user to write to
+        :param int x: X coordinate of the chip
+        :param int y: Y coordinate of the chip
+        :param int p: Virtual processor identifier on the chip
+        :param int value: The value to write
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If x, y, p does not identify a valid processor
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.write_user(user, x, y, p, value)
 
     @classmethod
     def wait_for_cores_to_be_in_state(

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -474,7 +474,7 @@ class SpiNNManDataView(MachineDataView):
             If a response indicates an error during the exchange
         """
         try:
-            return cls.__data._transceiver.lood(
+            return cls.__data._transceiver.execute_flood(
                 core_subsets, executable, app_id, n_bytes=None, wait=False,
                 is_filename=False)
         except AttributeError as ex:

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -190,9 +190,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.get_cpu_information_from_core(
                 x, y, p)
         except AttributeError as ex:
-           if cls.__data._transceiver is None:
+            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-           raise
+            raise
 
     @classmethod
     def read_fixed_route(cls, x, y, app_id):
@@ -213,9 +213,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.read_fixed_route(x, y, app_id)
         except AttributeError as ex:
-           if cls.__data._transceiver is None:
+            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-           raise
+            raise
 
     @classmethod
     def read_iobuf(cls, core_subsets=None):
@@ -246,9 +246,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_iobuf(core_subsets)
         except AttributeError as ex:
-           if cls.__data._transceiver is None:
+            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-           raise
+            raise
 
     @classmethod
     def read_memory(cls, x, y, base_address, length, cpu=0):
@@ -351,9 +351,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_router_diagnostics(x, y)
         except AttributeError as ex:
-               if cls.__data._transceiver is None:
-                    raise cls._exception("transceiver") from ex
-               raise
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_core_tags(cls, connection=None):
@@ -383,9 +383,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_tags(connection)
         except AttributeError as ex:
-               if cls.__data._transceiver is None:
-                    raise cls._exception("transceiver") from ex
-               raise
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_word(cls, x, y, base_address, cpu=0):
@@ -503,9 +503,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.read_user(user, x, y, p)
         except AttributeError as ex:
-           if cls.__data._transceiver is None:
+            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-           raise
+        raise
 
     @classmethod
     def write_control_sync(cls, do_sync):
@@ -521,9 +521,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.control_sync(do_sync)
         except AttributeError as ex:
-           if cls.__data._transceiver is None:
+            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-           raise
+            raise
 
     @classmethod
     def write_fixed_route(cls, x, y, fixed_route, app_id):

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -185,7 +185,7 @@ class SpiNNManDataView(MachineDataView):
         except AttributeError as ex:
            if cls.__data._transceiver is None:
                 raise cls._exception("transceiver") from ex
-            raise
+           raise
 
     @classmethod
     def read_memory(cls, x, y, base_address, length, cpu=0):
@@ -255,7 +255,7 @@ class SpiNNManDataView(MachineDataView):
         except AttributeError as ex:
                if cls.__data._transceiver is None:
                     raise cls._exception("transceiver") from ex
-                raise
+               raise
 
     @classmethod
     def read_word(cls, x, y, base_address, cpu=0):

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -221,38 +221,6 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
-    def write_multicast_routes(cls, x, y, app_id=None):
-        """
-        Get the current multicast routes set up on a chip.
-
-        Syntactic sugar for `get_transceiver().get_multicast_routes`.
-
-        :param int x:
-            The x-coordinate of the chip from which to get the routes
-        :param int y:
-            The y-coordinate of the chip from which to get the routes
-        :param int app_id:
-            The ID of the application to filter the routes for. If
-            not specified, will return all routes
-        :return: An iterable of multicast routes
-        :rtype: list(~spinn_machine.MulticastRoutingEntry)
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the transceiver is currently unavailable
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If a packet is received that has invalid parameters
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
-        try:
-            return cls.__data._transceiver.get_multicast_routes(x, y, app_id)
-        except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
-
-    @classmethod
     def read_router_diagnostics(cls, x, y):
         """
         Get router diagnostic information from a chip.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -311,6 +311,39 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
+    def write_fixed_route(cls, x, y, fixed_route, app_id):
+        """
+        Loads a fixed route routing table entry onto a chip's router.
+
+        Syntactic sugar for `get_transceiver().write_fixed_route`.
+
+        :param int x:
+            The x-coordinate of the chip onto which to load the routes
+        :param int y:
+            The y-coordinate of the chip onto which to load the routes
+        :param ~spinn_machine.FixedRouteEntry fixed_route:
+            the route for the fixed route entry on this chip
+        :param int app_id: The ID of the application with which to associate
+            the routes.  If not specified, defaults to 0.
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If any of the routes are invalid
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.load_fixed_route(
+                x, y, fixed_route, app_id)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def write_memory(cls, x, y, base_address, data, n_bytes=None, offset=0,
                      cpu=0, is_filename=False):
         """

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -343,11 +343,48 @@ class SpiNNManDataView(MachineDataView):
 
         :param int processor:
         :param ~.CoreSubset core_subset:
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
         """
         if cls.__data._transceiver is None:
             raise cls._exception("transceiver")
         return cls.__data._transceiver.update_provenance_and_exit(
             processor, core_subset)
+
+    @classmethod
+    def wait_for_cores_to_be_in_state(
+            cls, all_core_subsets, app_id, cpu_states, timeout,
+            error_states=None, progress_bar=None):
+        """
+        Waits for the specified cores running the given application to be
+        in some target state or states. Handles failures.
+
+        :param ~spinn_machine.CoreSubsets all_core_subsets:
+            the cores to check are in a given sync state
+        :param int app_id: the application ID that being used by the simulation
+        :param set(CPUState) cpu_states:
+            The expected states once the applications are ready; success is
+            when each application is in one of these states
+        :param float timeout:
+            The amount of time to wait in seconds for the cores to reach one
+            of the states
+        :param set(CPUState) error_states:
+            Set of states that the application can be in that indicate an
+            error, and so should raise an exception.
+            If None will use defaults defined in Transceiver method
+        :type error_states: None or set(CPUState)
+        :param progress_bar: Possible progress bar to update.
+        :type progress_bar: ~spinn_utilities.progress_bar.ProgressBar or None
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanTimeoutException:
+            If a timeout is specified and exceeded.
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.ait_for_cores_to_be_in_state(
+            all_core_subsets, app_id, cpu_states, timeout,
+            error_states, progress_bar)
 
     # app_id methods
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -389,6 +389,107 @@ class SpiNNManDataView(MachineDataView):
             raise
 
     @classmethod
+    def write_ip_tag(cls, ip_tag, use_sender=False):
+        """
+        Set up an IP tag.
+
+        Syntactic sugar for `get_transceiver().set_ip_tag`.
+
+        :param ~spinn_machine.tags.IPTag ip_tag:
+            The tag to set up.
+
+            .. note::
+                `board_address` can be `None`, in which case, the tag will be
+                assigned to all boards.
+        :param bool use_sender:
+            Optionally use the sender host and port instead of
+            the given host and port in the tag
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If the IP tag fields are incorrect
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.set_ip_tag(ip_tag, use_sender)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
+    def write_reverse_ip_tag(cls, reverse_ip_tag):
+        """
+        Set up a reverse IP tag.
+
+        Syntactic sugar for `get_transceiver().set_reverse_ip_tag`.
+
+        :param ~spinn_machine.tags.ReverseIPTag reverse_ip_tag:
+            The reverse tag to set up.
+
+            .. note::
+                The `board_address` field can be `None`, in which case, the tag
+                will be assigned to all boards.
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If the reverse IP tag fields are incorrect
+            * If a packet is received that has invalid parameters
+            * If the UDP port is one that is already used by SpiNNaker for
+                system functions
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.set_reverse_ip_tag(reverse_ip_tag)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
+    def write_clear_ip_tag(cls, tag, board_address=None):
+        """
+        Clear the setting of an IP tag.
+
+        Syntactic sugar for `get_transceiver().clear_ip_tag`.
+
+        :param int tag: The tag ID
+        :param str board_address:
+            Board address where the tag should be cleared.
+            If not specified, all AbstractSCPConnection connections will send
+            the message to clear the tag
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If the tag is not a valid tag
+            * If the connection cannot send SDP messages
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.clear_ip_tag(tag, board_address)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
     def write_memory(cls, x, y, base_address, data, n_bytes=None, offset=0,
                      cpu=0, is_filename=False):
         """

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -253,6 +253,35 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
+    def read_router_diagnostics(cls, x, y):
+        """
+        Get router diagnostic information from a chip.
+
+        Syntactic sugar for `get_transceiver().get_router_diagnostics`.
+
+        :param int x:
+            The x-coordinate of the chip from which to get the information
+        :param int y:
+            The y-coordinate of the chip from which to get the information
+        :return: The router diagnostic information
+        :rtype: RouterDiagnostics
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_router_diagnostics(x, y)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def read_word(cls, x, y, base_address, cpu=0):
         """
         Read a word (usually of SDRAM) from the board.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -361,21 +361,24 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver.send_signal(app_id, signal)
 
     @classmethod
-    def update_provenance_and_exit(cls, processor, core_subset):
+    def write_update_provenance_and_exit(cls, x, y, p):
         """
         Sends a command to update prevenance and exit
 
         Syntactic sugar for `get_transceiver().update_provenance_and_exit`.
 
-        :param int processor:
-        :param ~.CoreSubset core_subset:
+        :param int x:
+            The x-coordinate of the core
+        :param int y:
+            The y-coordinate of the core
+        :param int p:
+            The processor on the core
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the transceiver is currently unavailable
         """
         if cls.__data._transceiver is None:
             raise cls._exception("transceiver")
-        return cls.__data._transceiver.update_provenance_and_exit(
-            processor, core_subset)
+        return cls.__data._transceiver.update_provenance_and_exit(x, y, p)
 
     @classmethod
     def wait_for_cores_to_be_in_state(

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -400,6 +400,62 @@ class SpiNNManDataView(MachineDataView):
             x, y, base_address, data, n_bytes, offset, cpu, is_filename)
 
     @classmethod
+    def write_clear_multicast_routes(cls, x, y):
+        """
+        Remove all the multicast routes on a chip.
+
+        Syntactic sugar for `get_transceiver().clear_multicast_routes`.
+
+        :param int x: The x-coordinate of the chip on which to clear the routes
+        :param int y: The y-coordinate of the chip on which to clear the routes
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.clear_multicast_routes(x, y)
+
+    @classmethod
+    def write_multicast_routes(cls, x, y, routes, app_id):
+        """
+        Load a set of multicast routes on to a chip.
+
+        Syntactic sugar for `get_transceiver().load_multicast_routes`.
+
+        :param int x:
+            The x-coordinate of the chip onto which to load the routes
+        :param int y:
+            The y-coordinate of the chip onto which to load the routes
+        :param iterable(~spinn_machine.MulticastRoutingEntry) routes:
+            An iterable of multicast routes to load
+        :param int app_id: The ID of the application with which to associate
+            the routes.  If not specified, defaults to 0.
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If any of the routes are invalid
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.load_multicast_routes(
+            x, y, routes, app_id)
+
+    @classmethod
     def write_signal(cls, app_id, signal):
         """
         Writes/ Sends a signal to an application.

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -365,9 +365,10 @@ class SpiNNManDataView(MachineDataView):
         :param set(CPUState) cpu_states:
             The expected states once the applications are ready; success is
             when each application is in one of these states
-        :param float timeout:
+        :param timeout:
             The amount of time to wait in seconds for the cores to reach one
-            of the states
+            of the states.
+        :tpye timeout: float or None
         :param set(CPUState) error_states:
             Set of states that the application can be in that indicate an
             error, and so should raise an exception.
@@ -382,9 +383,30 @@ class SpiNNManDataView(MachineDataView):
         """
         if cls.__data._transceiver is None:
             raise cls._exception("transceiver")
-        return cls.__data._transceiver.ait_for_cores_to_be_in_state(
+        return cls.__data._transceiver.wait_for_cores_to_be_in_state(
             all_core_subsets, app_id, cpu_states, timeout,
             error_states, progress_bar)
+
+    @classmethod
+    def clear_router_diagnostic_counters(cls, x, y):
+        """
+        Clear router diagnostic information on a chip.
+
+        :param int x: The x-coordinate of the chip
+        :param int y: The y-coordinate of the chip
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If a packet is received that has invalid parameters or a counter
+            ID is out of range
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.clear_router_diagnostic_counters(x, y)
 
     # app_id methods
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -393,6 +393,30 @@ class SpiNNManDataView(MachineDataView):
         return cls.__data._transceiver.send_signal(app_id, signal)
 
     @classmethod
+    def write_stop_application(cls, app_id):
+        """
+        Sends a stop request for an app_id.
+
+        Syntactic sugar for `get_transceiver().stop_application`.
+
+        :param int app_id: The ID of the application to send to
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If app_id is not a valid application ID
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.stop_application(app_id)
+
+    @classmethod
     def write_update_provenance_and_exit(cls, x, y, p):
         """
         Sends a command to update prevenance and exit

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -335,6 +335,32 @@ class SpiNNManDataView(MachineDataView):
             x, y, base_address, data, n_bytes, offset, cpu, is_filename)
 
     @classmethod
+    def write_signal(cls, app_id, signal):
+        """
+        Writes/ Sends a signal to an application.
+
+        Syntactic sugar for `get_transceiver().send_signal`.
+
+        :param int app_id: The ID of the application to send to
+        :param Signal signal: The signal to send
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If signal is not a valid signal
+            * If app_id is not a valid application ID
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        if cls.__data._transceiver is None:
+            raise cls._exception("transceiver")
+        return cls.__data._transceiver.send_signal(app_id, signal)
+
+    @classmethod
     def update_provenance_and_exit(cls, processor, core_subset):
         """
         Sends a command to update prevenance and exit

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -303,6 +303,41 @@ class SpiNNManDataView(MachineDataView):
             raise
 
     @classmethod
+    def read_multicast_routes(cls, x, y, app_id=None):
+        """
+        Get the current multicast routes set up on a chip.
+
+        Syntactic sugar for `get_transceiver().get_multicast_routes`.
+
+        :param int x:
+            The x-coordinate of the chip from which to get the routes
+        :param int y:
+            The y-coordinate of the chip from which to get the routes
+        :param int app_id:
+            The ID of the application to filter the routes for. If
+            not specified, will return all routes
+        :return: An iterable of multicast routes
+        :rtype: list(~spinn_machine.MulticastRoutingEntry)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_multicast_routes(x, y, app_id)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
     def read_router_diagnostics(cls, x, y):
         """
         Get router diagnostic information from a chip.
@@ -315,8 +350,8 @@ class SpiNNManDataView(MachineDataView):
             The y-coordinate of the chip from which to get the information
         :return: The router diagnostic information
         :rtype: RouterDiagnostics
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
         :raise SpinnmanIOException:
             If there is an error communicating with the board
         :raise SpinnmanInvalidPacketException:
@@ -328,6 +363,38 @@ class SpiNNManDataView(MachineDataView):
         """
         try:
             return cls.__data._transceiver.get_router_diagnostics(x, y)
+        except AttributeError as ex:
+               if cls.__data._transceiver is None:
+                    raise cls._exception("transceiver") from ex
+               raise
+
+    @classmethod
+    def read_tags(cls, connection=None):
+        """
+        Get the current set of tags that have been set on the board.
+
+        Syntactic sugar for `get_transceiver().get_tags`.
+
+        :param AbstractSCPConnection connection:
+            Connection from which the tags should be received.
+            If not specified, all AbstractSCPConnection connections will be
+            queried and the response will be combined.
+        :return: An iterable of tags
+        :rtype: iterable(~spinn_machine.tags.AbstractTag)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If the connection cannot send SDP messages
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.get_tags(connection)
         except AttributeError as ex:
                if cls.__data._transceiver is None:
                     raise cls._exception("transceiver") from ex

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -257,6 +257,28 @@ class SpiNNManDataView(MachineDataView):
             raise cls._exception("transceiver") from ex
 
     @classmethod
+    def read_cores_in_state(cls, all_core_subsets, states):
+        """
+        Get all cores that are in a given state or set of states.
+
+        Syntactic sugar for `get_transceiver().get_cores_in_state`.
+
+        :param ~spinn_machine.CoreSubsets all_core_subsets:
+            The cores to filter
+        :param states: The state or states to filter on
+        :type states: CPUState or set(CPUState)
+        :return: Core subsets object containing cores in the given state(s)
+        :rtype: CPUInfos
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        """
+        try:
+            return cls.__data._transceiver.get_cores_in_state(
+                all_core_subsets, states)
+        except AttributeError as ex:
+            raise cls._exception("transceiver") from ex
+
+    @classmethod
     def write_memory(cls, x, y, base_address, data, n_bytes=None, offset=0,
                      cpu=0, is_filename=False):
         """

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -150,7 +150,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_core_state_count(app_id, state)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_cpu_information_from_core(cls, x, y, p):
@@ -181,7 +183,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.get_cpu_information_from_core(
                 x, y, p)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+           if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_memory(cls, x, y, base_address, length, cpu=0):
@@ -218,7 +222,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.read_memory(
                 x, y, base_address, length, cpu)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_router_diagnostics(cls, x, y):
@@ -247,7 +253,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.get_router_diagnostics(x, y)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+               if cls.__data._transceiver is None:
+                    raise cls._exception("transceiver") from ex
+                raise
 
     @classmethod
     def read_word(cls, x, y, base_address, cpu=0):
@@ -283,7 +291,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.read_word(
                 x, y, base_address, cpu)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_cores_in_state(cls, all_core_subsets, states):
@@ -305,7 +315,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.get_cores_in_state(
                 all_core_subsets, states)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def read_user(cls, user, x, y, p):
@@ -337,7 +349,9 @@ class SpiNNManDataView(MachineDataView):
         try:
             return cls.__data._transceiver.read_user(user, x, y, p)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+           if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+           raise
 
     @classmethod
     def write_fixed_route(cls, x, y, fixed_route, app_id):
@@ -370,7 +384,9 @@ class SpiNNManDataView(MachineDataView):
             return cls.__data._transceiver.load_fixed_route(
                 x, y, fixed_route, app_id)
         except AttributeError as ex:
-            raise cls._exception("transceiver") from ex
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_memory(cls, x, y, base_address, data, n_bytes=None, offset=0,
@@ -423,10 +439,13 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.write_memory(
-            x, y, base_address, data, n_bytes, offset, cpu, is_filename)
+        try:
+            return cls.__data._transceiver.write_memory(
+                x, y, base_address, data, n_bytes, offset, cpu, is_filename)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_clear_multicast_routes(cls, x, y):
@@ -448,9 +467,12 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.clear_multicast_routes(x, y)
+        try:
+            return cls.__data._transceiver.clear_multicast_routes(x, y)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_multicast_routes(cls, x, y, routes, app_id):
@@ -479,10 +501,13 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.load_multicast_routes(
-            x, y, routes, app_id)
+        try:
+            return cls.__data._transceiver.load_multicast_routes(
+                x, y, routes, app_id)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_signal(cls, app_id, signal):
@@ -506,9 +531,12 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.send_signal(app_id, signal)
+        try:
+            return cls.__data._transceiver.send_signal(app_id, signal)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_stop_application(cls, app_id):
@@ -530,9 +558,12 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.stop_application(app_id)
+        try:
+            return cls.__data._transceiver.stop_application(app_id)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_update_provenance_and_exit(cls, x, y, p):
@@ -550,9 +581,12 @@ class SpiNNManDataView(MachineDataView):
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the transceiver is currently unavailable
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.update_provenance_and_exit(x, y, p)
+        try:
+            return cls.__data._transceiver.update_provenance_and_exit(x, y, p)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def write_user(cls, user, x, y, p, value):
@@ -617,11 +651,14 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanTimeoutException:
             If a timeout is specified and exceeded.
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.wait_for_cores_to_be_in_state(
-            all_core_subsets, app_id, cpu_states, timeout,
-            error_states, progress_bar)
+        try:
+            return cls.__data._transceiver.wait_for_cores_to_be_in_state(
+                all_core_subsets, app_id, cpu_states, timeout,
+                error_states, progress_bar)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def clear_router_diagnostic_counters(cls, x, y):
@@ -645,9 +682,13 @@ class SpiNNManDataView(MachineDataView):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.clear_router_diagnostic_counters(x, y)
+        try:
+            return cls.__data._transceiver.clear_router_diagnostic_counters(
+                x, y)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     @classmethod
     def malloc_sdram(cls, x, y, size, app_id, tag=None):
@@ -669,9 +710,13 @@ class SpiNNManDataView(MachineDataView):
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the transceiver is currently unavailable
         """
-        if cls.__data._transceiver is None:
-            raise cls._exception("transceiver")
-        return cls.__data._transceiver.malloc_sdram(x, y, size, app_id, tag)
+        try:
+            return cls.__data._transceiver.malloc_sdram(
+                x, y, size, app_id, tag)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
 
     # app_id methods
 

--- a/spinnman/data/spinnman_data_view.py
+++ b/spinnman/data/spinnman_data_view.py
@@ -389,6 +389,67 @@ class SpiNNManDataView(MachineDataView):
             raise
 
     @classmethod
+    def write_flood(
+            cls, core_subsets, executable, app_id, n_bytes=None, wait=False,
+            is_filename=False):
+        """
+        Start an executable running on multiple places on the board.  This
+        will be optimised based on the selected cores, but it may still
+        require a number of communications with the board to execute.
+
+        Syntactic sugar for `get_transceiver().execute_flood`.
+
+        :param ~spinn_machine.CoreSubsets core_subsets:
+            Which cores on which chips to start the executable
+        :param executable:
+            The data that is to be executed. Should be one of the following:
+
+            * An instance of RawIOBase
+            * A bytearray
+            * A filename of an executable (in which case `is_filename` must be
+              set to True)
+        :type executable:
+            ~io.RawIOBase or bytes or bytearray or str
+        :param int app_id:
+            The ID of the application with which to associate the executable
+        :param int n_bytes:
+            The size of the executable data in bytes. If not specified:
+
+            * If `executable` is an RawIOBase, an error is raised
+            * If `executable` is a bytearray, the length of the bytearray will
+              be used
+            * If `executable` is an int, 4 will be used
+            * If `executable` is a str, the length of the file will be used
+        :param bool wait:
+            True if the processors should enter a "wait" state on loading
+        :param bool is_filename: True if the data is a filename
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the transceiver is currently unavailable
+        :raise SpinnmanIOException:
+            * If there is an error communicating with the board
+            * If there is an error reading the executable
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If one of the specified cores is not valid
+            * If `app_id` is an invalid application ID
+            * If a packet is received that has invalid parameters
+            * If `executable` is an RawIOBase but `n_bytes` is not specified
+            * If `executable` is an int and `n_bytes` is more than 4
+            * If `n_bytes` is less than 0
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        try:
+            return cls.__data._transceiver.lood(
+                core_subsets, executable, app_id, n_bytes=None, wait=False,
+                is_filename=False)
+        except AttributeError as ex:
+            if cls.__data._transceiver is None:
+                raise cls._exception("transceiver") from ex
+            raise
+
+    @classmethod
     def write_ip_tag(cls, ip_tag, use_sender=False):
         """
         Set up an IP tag.

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import struct
-from spinnman.constants import CPU_USER_0_START_ADDRESS
 from spinnman.model.enums import CPUState, RunTimeError, MailboxCommand
 
 CPU_INFO_BYTES = 128

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import struct
+from spinnman.constants import CPU_USER_0_START_ADDRESS
 from spinnman.model.enums import CPUState, RunTimeError, MailboxCommand
 
 CPU_INFO_BYTES = 128
-CPU_USER_0_START_ADDRESS = 112
 
 _INFO_PATTERN = struct.Struct("< 32s 3I 2B 2B 2I 2B H 3I 16s 2I 16x 4I")
 _REGISTERS_PATTERN = struct.Struct("<IIIIIIII")

--- a/spinnman/model/enums/__init__.py
+++ b/spinnman/model/enums/__init__.py
@@ -26,10 +26,13 @@ from .mailbox_command import MailboxCommand
 from .p2p_table_route import P2PTableRoute
 from .run_time_error import RunTimeError
 from .router_error import RouterError
+from .sdp_ports import SDP_PORTS
+from .sdp_running_message_codes import SDP_RUNNING_MESSAGE_CODES
 
 __all__ = ["CPUState", "DiagnosticFilterDefaultRoutingStatus",
            "DiagnosticFilterDestination",
            "DiagnosticFilterEmergencyRoutingStatus",
            "DiagnosticFilterPacketType", "DiagnosticFilterPayloadStatus",
            "DiagnosticFilterSource", "ExecutableType", "MailboxCommand",
-           "P2PTableRoute", "RouterError", "RunTimeError"]
+           "P2PTableRoute", "RouterError", "RunTimeError", "SDP_PORTS",
+           "SDP_RUNNING_MESSAGE_CODES"]

--- a/spinnman/model/enums/sdp_ports.py
+++ b/spinnman/model/enums/sdp_ports.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2014 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class SDP_PORTS(Enum):
+    """
+    SDP port handling output buffering data streaming.
+    """
+
+    #: Command port for the buffered in functionality.
+    INPUT_BUFFERING_SDP_PORT = 1
+    #: Command port for the buffered out functionality.
+    OUTPUT_BUFFERING_SDP_PORT = 2
+    #: Command port for resetting runtime, etc.
+    #: See :py:class:`SDP_RUNNING_MESSAGE_CODES`
+    RUNNING_COMMAND_SDP_PORT = 3
+    #: Extra monitor core reinjection control protocol.
+    #: See :py:class:`ReinjectorSCPCommands`
+    EXTRA_MONITOR_CORE_REINJECTION = 4
+    #: Extra monitor core outbound data transfer protocol
+    EXTRA_MONITOR_CORE_DATA_SPEED_UP = 5
+    #: Extra monitor core inbound data transfer protocol
+    #: See :py:class:`SpeedupInSCPCommands`
+    EXTRA_MONITOR_CORE_DATA_IN_SPEED_UP = 6

--- a/spinnman/model/enums/sdp_running_message_codes.py
+++ b/spinnman/model/enums/sdp_running_message_codes.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2014 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class SDP_RUNNING_MESSAGE_CODES(Enum):
+    """
+    Codes for sending control messages to spin1_api.
+    """
+    SDP_STOP_ID_CODE = 6
+    SDP_NEW_RUNTIME_ID_CODE = 7
+    SDP_UPDATE_PROVENCE_REGION_AND_EXIT = 8
+    SDP_CLEAR_IOBUF_CODE = 9

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -2824,28 +2824,25 @@ class Transceiver(AbstractContextManager):
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(DoSync(do_sync))
 
-    def update_provenance_and_exit(self, processor, core_subset):
+    def update_provenance_and_exit(self, x, y, p):
         """
         Sends a command to update prevenance and exit
 
-        :param int processor:
-        :param ~.CoreSubset core_subset:
+        :param int x:
+            The x-coordinate of the core
+        :param int y:
+            The y-coordinate of the core
+        :param int p:
+            The processor on the core
         """
-        app_id = SpiNNManDataView.get_app_id()
-        byte_data = _ONE_WORD.pack(
-            SDP_RUNNING_MESSAGE_CODES
-                .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)
         # Send these signals to make sure the application isn't stuck
-        self.send_signal(app_id, Signal.SYNC0)
-        self.send_signal(app_id, Signal.SYNC1)
         self.send_sdp_message(SDPMessage(
             sdp_header=SDPHeader(
                 flags=SDPFlag.REPLY_NOT_EXPECTED,
                 destination_port=SDP_PORTS.RUNNING_COMMAND_SDP_PORT.value,
-                destination_cpu=processor,
-                destination_chip_x=core_subset.x,
-                destination_chip_y=core_subset.y),
-            data=byte_data))
+                destination_chip_x=x, destination_chip_y=y, destination_cpu=p),
+            data=_ONE_WORD.pack(SDP_RUNNING_MESSAGE_CODES
+                                .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)))
 
     def __str__(self):
         addr = self._scamp_connections[0].remote_ip_address

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -965,8 +965,8 @@ class Transceiver(AbstractContextManager):
         if user < 0 or user > CPU_MAX_USER:
             raise ValueError(
                 f"Incorrect user number {user}")
-        return get_vcpu_address(p) + CPU_USER_0_START_ADDRESS + \
-               CPU_USER_OFFSET * user
+        return (get_vcpu_address(p) + CPU_USER_0_START_ADDRESS +
+                CPU_USER_OFFSET * user)
 
     def read_user(self, user, x, y, p):
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -49,7 +49,7 @@ from spinnman.model.enums import (
 from spinnman.messages.scp.impl.get_chip_info import GetChipInfo
 from spinnman.messages.spinnaker_boot import (
     SystemVariableDefinition, SpinnakerBootMessages)
-from spinnman.messages.scp.enums import PowerCommand
+from spinnman.messages.scp.enums import PowerCommand, Signal
 from spinnman.messages.scp.abstract_messages import AbstractSCPRequest
 from spinnman.messages.scp.impl import (
     BMPSetLed, BMPGetVersion, SetPower, ReadADC, ReadFPGARegister,

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -948,6 +948,20 @@ class Transceiver(AbstractContextManager):
             data_item.data_type.struct_code,
             self.read_memory(x, y, addr, data_item.data_type.value))[0]
 
+    def get_clock_drift(self, x, y):
+        """
+        Get the clock drift
+
+        :param int x: The x-coordinate of the chip to get drift for
+        :param int y: The y-coordinate of the chip to get drift for
+        """
+        DRIFT_FP = 1 << 17
+
+        drift = self._get_sv_data(x, y, SystemVariableDefinition.clock_drift)
+        drift = struct.unpack("<i", struct.pack("<I", drift))[0]
+        drift = drift / DRIFT_FP
+        return drift
+
     @staticmethod
     def get_user_register_address_from_core(user, p):
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -49,7 +49,7 @@ from spinnman.model.enums import (
 from spinnman.messages.scp.impl.get_chip_info import GetChipInfo
 from spinnman.messages.spinnaker_boot import (
     SystemVariableDefinition, SpinnakerBootMessages)
-from spinnman.messages.scp.enums import PowerCommand, Signal
+from spinnman.messages.scp.enums import PowerCommand
 from spinnman.messages.scp.abstract_messages import AbstractSCPRequest
 from spinnman.messages.scp.impl import (
     BMPSetLed, BMPGetVersion, SetPower, ReadADC, ReadFPGARegister,
@@ -1303,43 +1303,6 @@ class Transceiver(AbstractContextManager):
             process = ApplicationCopyRunProcess(
                 self._scamp_connection_selector)
             process.run(n_bytes, app_id, core_subsets, chksum, wait)
-
-    def execute_application(self, executable_targets, app_id):
-        """
-        Execute a set of binaries that make up a complete application on
-        specified cores, wait for them to be ready and then start all of the
-        binaries.
-
-        .. note::
-            This will get the binaries into c_main but will not signal the
-            barrier.
-
-        :param ExecutableTargets executable_targets:
-            The binaries to be executed and the cores to execute them on
-        :param int app_id: The app_id to give this application
-        """
-        # Execute each of the binaries and get them in to a "wait" state
-        for binary in executable_targets.binaries:
-            core_subsets = executable_targets.get_cores_for_binary(binary)
-            self.execute_flood(
-                core_subsets, binary, app_id, wait=True, is_filename=True)
-
-        # Sleep to allow cores to get going
-        time.sleep(0.5)
-
-        # Check that the binaries have reached a wait state
-        count = self.get_core_state_count(app_id, CPUState.READY)
-        if count < executable_targets.total_processors:
-            cores_ready = self.get_cores_not_in_state(
-                executable_targets.all_core_subsets, [CPUState.READY])
-            if len(cores_ready) > 0:
-                raise SpinnmanException(
-                    f"Only {count} of {executable_targets.total_processors} "
-                    "cores reached ready state: "
-                    f"{cores_ready.get_status_string()}")
-
-        # Send a signal telling the application to start
-        self.send_signal(app_id, Signal.START)
 
     def power_on_machine(self):
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -31,8 +31,7 @@ from spinn_machine import CoreSubsets
 from spinn_machine.spinnaker_triad_geometry import SpiNNakerTriadGeometry
 from spinnman.constants import (
     BMP_POST_POWER_ON_SLEEP_TIME, BMP_POWER_ON_TIMEOUT, BMP_TIMEOUT,
-    CPU_USER_0_START_ADDRESS, CPU_USER_1_START_ADDRESS,
-    CPU_USER_2_START_ADDRESS, CPU_USER_3_START_ADDRESS,
+    CPU_USER_0_START_ADDRESS, CPU_USER_OFFSET, CPU_MAX_USER,
     IPTAG_TIME_OUT_WAIT_TIMES, SCP_SCAMP_PORT, SYSTEM_VARIABLE_BASE_ADDRESS,
     UDP_BOOT_CONNECTION_DEFAULT_PORT, NO_ROUTER_DIAGNOSTIC_FILTERS,
     ROUTER_REGISTER_BASE_ADDRESS, ROUTER_DEFAULT_FILTERS_MAX_POSITION,
@@ -950,28 +949,34 @@ class Transceiver(AbstractContextManager):
             self.read_memory(x, y, addr, data_item.data_type.value))[0]
 
     @staticmethod
-    def get_user_0_register_address_from_core(p):
+    def get_user_register_address_from_core(user, p):
         """
-        Get the address of user 0 for a given processor on the board.
+        Get the address of this user for a given processor on the board.
 
         .. note::
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
+        :param int user: The user number to get the address for
         :param int p: The ID of the processor to get the user 0 address from
         :return: The address for user 0 register for this processor
         :rtype: int
         """
-        return get_vcpu_address(p) + CPU_USER_0_START_ADDRESS
+        if user < 0 or user > CPU_MAX_USER:
+            raise ValueError(
+                f"Incorrect user number {user}")
+        return get_vcpu_address(p) + CPU_USER_0_START_ADDRESS + \
+               CPU_USER_OFFSET * user
 
-    def read_user_0(self, x, y, p):
+    def read_user(self, user, x, y, p):
         """
-        Get the contents of the user_0 register for the given processor.
+        Get the contents of this user register for the given processor.
 
         .. note::
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
+        :param int user: The user number to get the address for
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param int p: Virtual processor identifier on the chip
@@ -985,61 +990,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.get_user_0_register_address_from_core(p)
+        addr = self.get_user_register_address_from_core(user, p)
         return self.read_word(x, y, addr)
-
-    def read_user_1(self, x, y, p):
-        """
-        Get the contents of the user_1 register for the given processor.
-
-        :param int x: X coordinate of the chip
-        :param int y: Y coordinate of the chip
-        :param int p: Virtual processor identifier on the chip
-        :rtype: int
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If x, y, p does not identify a valid processor
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
-        addr = self.get_user_1_register_address_from_core(p)
-        return self.read_word(x, y, addr)
-
-    @staticmethod
-    def get_user_1_register_address_from_core(p):
-        """
-        Get the address of user 1 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 1 address from
-        :return: The address for user 1 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_1_START_ADDRESS
-
-    @staticmethod
-    def get_user_2_register_address_from_core(p):
-        """
-        Get the address of user 2 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 2 address from
-        :return: The address for user 2 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_2_START_ADDRESS
-
-    @staticmethod
-    def get_user_3_register_address_from_core(p):
-        """
-        Get the address of user 3 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 3 address from
-        :return: The address for user 3 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_3_START_ADDRESS
 
     def get_cpu_information_from_core(self, x, y, p):
         """
@@ -1641,14 +1593,15 @@ class Transceiver(AbstractContextManager):
                 x, y, cpu, base_address, data, offset, n_bytes, get_sum)
         return n_bytes, chksum
 
-    def write_user_0(self, x, y, p, value):
+    def write_user(self, user, x, y, p, value):
         """
-        Write to the user_0 register for the given processor.
+        Write to this user register for the given processor.
 
         .. note::
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
+        :param int user: The user to write to
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param int p: Virtual processor identifier on the chip
@@ -1662,27 +1615,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.get_user_0_register_address_from_core(p)
-        self.write_memory(x, y, addr, int(value))
-
-    def write_user_1(self, x, y, p, value):
-        """
-        Write to the user_1 register for the given processor.
-
-        :param int x: X coordinate of the chip
-        :param int y: Y coordinate of the chip
-        :param int p: Virtual processor identifier on the chip
-        :param int value: The value to write
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If x, y, p does not identify a valid processor
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
-        addr = self.get_user_1_register_address_from_core(p)
+        addr = self.get_user_register_address_from_core(user, p)
         self.write_memory(x, y, addr, int(value))
 
     def write_neighbour_memory(self, x, y, link, base_address, data,

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -45,7 +45,8 @@ from spinnman.exceptions import (
     SpinnmanUnexpectedResponseCodeException,
     SpiNNManCoresNotInStateException)
 from spinnman.model import CPUInfos, DiagnosticFilter, MachineDimensions
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import (
+    CPUState, SDP_PORTS, SDP_RUNNING_MESSAGE_CODES)
 from spinnman.messages.scp.impl.get_chip_info import GetChipInfo
 from spinnman.messages.spinnaker_boot import (
     SystemVariableDefinition, SpinnakerBootMessages)
@@ -56,6 +57,7 @@ from spinnman.messages.scp.impl import (
     WriteFPGARegister, IPTagSetTTO, ReverseIPTagSet, ReadMemory,
     CountState, WriteMemory, SetLED, ApplicationRun, SendSignal, AppStop,
     IPTagSet, IPTagClear, RouterClear, DoSync)
+from spinnman.messages.sdp import SDPFlag, SDPHeader, SDPMessage
 from spinnman.connections.udp_packet_connections import (
     BMPConnection, BootConnection, SCAMPConnection)
 from spinnman.processes import (
@@ -2820,6 +2822,29 @@ class Transceiver(AbstractContextManager):
         """
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(DoSync(do_sync))
+
+    def update_provenance_and_exit(self, processor, core_subset):
+        """
+        Sends a command to update prevenance and exit
+
+        :param int processor:
+        :param ~.CoreSubset core_subset:
+        """
+        app_id = SpiNNManDataView.get_app_id()
+        byte_data = _ONE_WORD.pack(
+            SDP_RUNNING_MESSAGE_CODES
+                .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)
+        # Send these signals to make sure the application isn't stuck
+        self.send_signal(app_id, Signal.SYNC0)
+        self.send_signal(app_id, Signal.SYNC1)
+        self.send_sdp_message(SDPMessage(
+            sdp_header=SDPHeader(
+                flags=SDPFlag.REPLY_NOT_EXPECTED,
+                destination_port=SDP_PORTS.RUNNING_COMMAND_SDP_PORT.value,
+                destination_cpu=processor,
+                destination_chip_x=core_subset.x,
+                destination_chip_y=core_subset.y),
+            data=byte_data))
 
     def __str__(self):
         addr = self._scamp_connections[0].remote_ip_address

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -954,6 +954,8 @@ class Transceiver(AbstractContextManager):
 
         :param int x: The x-coordinate of the chip to get drift for
         :param int y: The y-coordinate of the chip to get drift for
+        :rtype: int
+
         """
         DRIFT_FP = 1 << 17
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1971,11 +1971,8 @@ class Transceiver(AbstractContextManager):
             logger.info(self.__where_is_xy(x, y))
 
     def wait_for_cores_to_be_in_state(
-            self, all_core_subsets, app_id, cpu_states, timeout=None,
-            time_between_polls=0.1,
-            error_states=frozenset({
-                CPUState.RUN_TIME_EXCEPTION, CPUState.WATCHDOG}),
-            counts_between_full_check=100, progress_bar=None):
+            self, all_core_subsets, app_id, cpu_states, timeout,
+            error_states=None, progress_bar=None):
         """
         Waits for the specified cores running the given application to be
         in some target state or states. Handles failures.
@@ -1986,16 +1983,15 @@ class Transceiver(AbstractContextManager):
         :param set(CPUState) cpu_states:
             The expected states once the applications are ready; success is
             when each application is in one of these states
-        :param float timeout:
+        :param timeout:
             The amount of time to wait in seconds for the cores to reach one
-            of the states
-        :param float time_between_polls: Time between checking the state
+            of the states.
+        :tpye timeout: float or None
         :param set(CPUState) error_states:
             Set of states that the application can be in that indicate an
-            error, and so should raise an exception
-        :param int counts_between_full_check:
-            The number of times to use the count signal before instead using
-            the full CPU state check
+            error, and so should raise an exception.
+            Defaults to RUN_TIME_EXCEPTION and WATCHDOG
+        :type error_states: None or  set(CPUState)
         :param progress_bar: Possible progress bar to update.
         :type progress_bar: ~spinn_utilities.progress_bar.ProgressBar or None
         :raise SpinnmanTimeoutException:
@@ -2005,7 +2001,12 @@ class Transceiver(AbstractContextManager):
         processors_ready = 0
         max_processors_ready = 0
         timeout_time = None if timeout is None else time.time() + timeout
+        time_between_polls = 0.1
+        counts_between_full_check = 100
         tries = 0
+        if error_states is None:
+            error_states = frozenset({
+                CPUState.RUN_TIME_EXCEPTION, CPUState.WATCHDOG})
         while (processors_ready < len(all_core_subsets) and
                (timeout_time is None or time.time() < timeout_time)):
 

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -38,7 +38,7 @@ class TestData(unittest.TestCase):
         # Use manual_check to verify this without dependency
         SpiNNManDataWriter.setup()
         with self.assertRaises(DataNotYetAvialable):
-            SpiNNManDataView.get_transceiver()
+            SpiNNManDataView.get_machine()
 
     def test_mock(self):
         SpiNNManDataWriter.mock()
@@ -48,11 +48,8 @@ class TestData(unittest.TestCase):
 
     def test_transceiver(self):
         writer = SpiNNManDataWriter.setup()
-        with self.assertRaises(DataNotYetAvialable):
-            SpiNNManDataView.get_transceiver()
         self.assertFalse(SpiNNManDataView.has_transceiver())
         writer.set_transceiver(MockTranceiver())
-        SpiNNManDataView.get_transceiver()
         self.assertTrue(SpiNNManDataView.has_transceiver())
         with self.assertRaises(TypeError):
             writer.set_transceiver("bacon")


### PR DESCRIPTION
As part of the preparation for supporting spin2 boards these PRs contain 1 approach to centralizing the calls to Transceiver.

The ideal solution would have been to have the View get_tranceiver method returns Java style TransceiverInterface where only methods in that interface can be called. But this is python!

We could have the View return a Wrapper object which encapsulates a hidden transceiver and has pass through methods,
But then you have ...View.get_transceiver_wrapper().malloc_sdram(...
When with this approach it is just
...View.malloc_sdram(...

So the View is in affect a Transceiver Wrapper

I am not sure of the naming of the View methods.
The pattern I have followed is
write - for any methods that send data via the Transceiver
read - for any methods which extract data using the transceiver
malloc_sdram as it is both sending and receiving 
(Note I intentional avoided set and get as these are used for data held by the View )

An alternative naming pattern is txrx_ followed by the Transceiver name

Still to do is convert where possible the SpiNNMan usages to the View as well.

Still to do is make all other Transceiver methods double underscore

Possibly add an AdstractTransciver with the methods call from the View

== Changes made which should be kept even if this PR is refused.

 - https://github.com/SpiNNakerManchester/SpiNNMan/pull/332

 - Moving get_clock_drift into the Transceiver

- Converting user_0 user-1 and user_2 methods into generic methods with the user_num as a parameter

- wait_for_cores_to_be_in_state method change time_between_polls and counts_between_full_check to be constants as never changed by callers

- Move update_provenance_and_exit into the transceiver. Which required moving SDP_PORTS and SDP_RUNNING_MESSAGE_CODES 




If done must be done at the same time as: