### PR TITLE
Cores in state

### DIFF
--- a/quick_tests/quick_tests.py
+++ b/quick_tests/quick_tests.py
@@ -189,7 +189,7 @@ def print_transceiver_tests(transceiver):
             time.sleep(0.1)
 
     with Section("CPU Information"):
-        cpu_infos = transceiver.get_cpu_information(core_subsets)
+        cpu_infos = transceiver.get_cpu_infos(core_subsets)
         cpu_infos = sorted(cpu_infos, key=lambda x: (x.x, x.y, x.p))
         print("{} CPUs".format(len(cpu_infos)))
         for cpu_info in cpu_infos:
@@ -211,7 +211,7 @@ def print_transceiver_tests(transceiver):
     with Section("Stop Application"):
         transceiver.send_signal(app_id, Signal.STOP)
         time.sleep(0.5)
-        cpu_infos = transceiver.get_cpu_information(core_subsets)
+        cpu_infos = transceiver.get_cpu_infos(core_subsets)
         cpu_infos = sorted(cpu_infos, key=lambda x: (x.x, x.y, x.p))
         print("{} CPUs".format(len(cpu_infos)))
         for cpu_info in cpu_infos:

--- a/spinnman/__init__.py
+++ b/spinnman/__init__.py
@@ -124,7 +124,7 @@ Use Cases
   determine if a simulation is complete or has gone into an error state.
 
 * :py:meth:`~spinnman.transceiver.Transceiver.get_iobuf`,
-  :py:meth:`~spinnman.transceiver.Transceiver.get_cpu_information` and
+  :py:meth:`~spinnman.transceiver.Transceiver.get_cpu_infos` and
   :py:meth:`~spinnman.transceiver.Transceiver.get_router_diagnostics` are used
   to diagnose a problem with a simulation.
 

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -48,11 +48,12 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
 
     all_cores = CoreSubsets(core_subsets=all_cores)
 
-    cores_finished = txrx.get_cpu_information(
-        all_cores, CPUState.FINISHED, True)
-    cores_running = txrx.get_cpu_information(all_cores, CPUState.RUNNING, True)
-    cores_watchdog = txrx.get_cpu_information(
-        all_cores, CPUState.WATCHDOG, True)
+    cpu_infos = txrx.get_cpu_infos(
+        all_cores,
+        [CPUState.FINISHED, CPUState.RUNNING, CPUState.WATCHDOG], True)
+    cores_finished = cpu_infos.infos_for_state(CPUState.FINISHED)
+    cores_running = cpu_infos.infos_for_state(CPUState.RUNNING)
+    cores_watchdog = cpu_infos.infos_for_state(CPUState.WATCHDOG)
 
     for (x, y, p), _ in cores_running:
         if p not in IGNORED_IDS:

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -48,9 +48,11 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
 
     all_cores = CoreSubsets(core_subsets=all_cores)
 
-    cores_finished = txrx.get_cores_in_state(all_cores, CPUState.FINISHED)
-    cores_running = txrx.get_cores_in_state(all_cores, CPUState.RUNNING)
-    cores_watchdog = txrx.get_cores_in_state(all_cores, CPUState.WATCHDOG)
+    cores_finished = txrx.get_cpu_information(
+        all_cores, CPUState.FINISHED, True)
+    cores_running = txrx.get_cpu_information(all_cores, CPUState.RUNNING, True)
+    cores_watchdog = txrx.get_cpu_information(
+        all_cores, CPUState.WATCHDOG, True)
 
     for (x, y, p), _ in cores_running:
         if p not in IGNORED_IDS:

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -49,13 +49,12 @@ class CPUInfo(object):
         "_user",
         "_x", "_y", "_p"]
 
-    def __init__(self, x, y, p, cpu_data, offset):
+    def __init__(self, x, y, p, cpu_data):
         """
         :param int x: The x-coordinate of a chip
         :param int y: The y-coordinate of a chip
         :param int p: The ID of a core on the chip
-        :param bytes cpu_data: A byte-string received from SDRAM on the board
-        :param int offset:
+        :param tuple cpu_data: A byte-string received from SDRAM on the board
         """
         # pylint: disable=too-many-arguments
         self._x = x
@@ -77,7 +76,7 @@ class CPUInfo(object):
          self._iobuf_address, self._software_version,                # 2I  88
          # skipped                                                   # 16x 96
          user0, user1, user2, user3                                  # 4I  112
-         ) = _INFO_PATTERN.unpack_from(cpu_data, offset)
+         ) = cpu_data
 
         index = self._application_name.find(b'\0')
         if index != -1:

--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -24,16 +24,23 @@ class CPUInfos(object):
         self._cpu_infos = dict()
 
     def add_info(self, cpu_info):
+        """
+        Add a info on using its core coordinates.
+
+        :param ~spinnman.model.CPUInfo cpu_info:
+        """
         self._cpu_infos[cpu_info.x, cpu_info.y, cpu_info.p] = cpu_info
 
     def add_processor(self, x, y, processor_id, cpu_info):
         """
-        Add a processor on a given chip to the set.
+        Add a info on a given core.
 
         :param int x: The x-coordinate of the chip
         :param int y: The y-coordinate of the chip
         :param int processor_id: A processor ID
-        :param CPUInfo cpu_info: The CPU information for the core
+        :param CPUInfo cpu_info:
+            The CPU information for the core.
+            Not checked so could be None at test own risk
         """
         self._cpu_infos[x, y, processor_id] = cpu_info
 
@@ -43,6 +50,7 @@ class CPUInfos(object):
         The one per core core info.
 
         :return: iterable of x,y,p core info
+        :rtype: iterable(~spinnman.model.CPUInfo)
         """
         return iter(self._cpu_infos.items())
 
@@ -52,6 +60,7 @@ class CPUInfos(object):
     def iteritems(self):
         """
         Get an iterable of (x, y, p), cpu_info.
+        :rtype: (iterable(tuple(int, int, int),  ~spinnman.model.CPUInfo)
         """
         return iter(self._cpu_infos.items())
 
@@ -90,11 +99,20 @@ class CPUInfos(object):
 
     def get_cpu_info(self, x, y, p):
         """
-        Get the information for the given core on the given chip.
+        Get the information for the given core on the given core
+
+        :rtype: CpuInfo
         """
         return self._cpu_infos[x, y, p]
 
     def infos_for_state(self, state):
+        """
+        Creates a new CpuInfos object with Just the Infos that match the state.
+
+        :param ~spinnman.model.enums.CPUState state:
+        :return: New Infos object with the filtered infos if any
+        :rtype: CPUInfo
+        """
         for_state = CPUInfos()
         for info in self._cpu_infos.values():
             if info.state == state:

--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -23,6 +23,9 @@ class CPUInfos(object):
     def __init__(self):
         self._cpu_infos = dict()
 
+    def add_info(self, cpu_info):
+        self._cpu_infos[cpu_info.x, cpu_info.y, cpu_info.p] = cpu_info
+
     def add_processor(self, x, y, processor_id, cpu_info):
         """
         Add a processor on a given chip to the set.
@@ -90,6 +93,13 @@ class CPUInfos(object):
         Get the information for the given core on the given chip.
         """
         return self._cpu_infos[x, y, p]
+
+    def infos_for_state(self, state):
+        for_state = CPUInfos()
+        for info in self._cpu_infos.values():
+            if info.state == state:
+                for_state.add_info(info)
+        return for_state
 
     def __str__(self):
         return str([f"{x}, {y}, {p} (ph: {info.physical_cpu_id})"

--- a/spinnman/processes/__init__.py
+++ b/spinnman/processes/__init__.py
@@ -21,6 +21,8 @@ from .de_alloc_sdram_process import DeAllocSDRAMProcess
 from .fixed_connection_selector import FixedConnectionSelector
 from .get_heap_process import GetHeapProcess
 from .get_cpu_info_process import GetCPUInfoProcess
+from .get_exclude_cpu_info_process import GetExcludeCPUInfoProcess
+from .get_include_cpu_info_process import GetIncludeCPUInfoProcess
 from .get_machine_process import GetMachineProcess
 from .get_routes_process import GetMultiCastRoutesProcess
 from .get_tags_process import GetTagsProcess
@@ -45,7 +47,9 @@ __all__ = ["AbstractMultiConnectionProcessConnectionSelector",
            "RoundRobinConnectionSelector",
            "AbstractMultiConnectionProcess",
            "ApplicationRunProcess", "ApplicationCopyRunProcess",
-           "DeAllocSDRAMProcess", "GetCPUInfoProcess", "GetHeapProcess",
+           "DeAllocSDRAMProcess", "GetCPUInfoProcess",
+           "GetExcludeCPUInfoProcess", "GetIncludeCPUInfoProcess",
+           "GetHeapProcess",
            "GetMachineProcess", "GetMultiCastRoutesProcess", "GetTagsProcess",
            "GetVersionProcess", "LoadFixedRouteRoutingEntryProcess",
            "LoadMultiCastRoutesProcess", "MallocSDRAMProcess",

--- a/spinnman/processes/get_cpu_info_process.py
+++ b/spinnman/processes/get_cpu_info_process.py
@@ -14,7 +14,7 @@
 
 import functools
 import struct
-from spinnman.model import CPUInfo
+from spinnman.model import CPUInfo, CPUInfos
 from spinnman.constants import CPU_INFO_BYTES
 from spinnman.utilities.utility_functions import get_vcpu_address
 from spinnman.messages.scp.impl import ReadMemory
@@ -34,10 +34,10 @@ class GetCPUInfoProcess(AbstractMultiConnectionProcess):
             AbstractMultiConnectionProcessConnectionSelector
         """
         super().__init__(connection_selector)
-        self._cpu_infos = list()
+        self._cpu_infos = CPUInfos()
 
     def _filter_and_add_repsonse(self, x, y, p, cpu_data):
-        self._cpu_infos.append(CPUInfo(x, y, p, cpu_data))
+        self._cpu_infos.add_info(CPUInfo(x, y, p, cpu_data))
 
     def __handle_response(self, x, y, p, response):
         cpu_data = _INFO_PATTERN.unpack_from(response.data, response.offset)

--- a/spinnman/processes/get_exclude_cpu_info_process.py
+++ b/spinnman/processes/get_exclude_cpu_info_process.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2015 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spinnman.model import CPUInfo
+from spinnman.model.enums import CPUState
+from .get_cpu_info_process import GetCPUInfoProcess
+
+
+class GetExcludeCPUInfoProcess(GetCPUInfoProcess):
+    __slots__ = [
+        "_states"]
+
+    def __init__(self, connection_selector, states):
+        """
+        :param connection_selector:
+        :type connection_selector:
+            AbstractMultiConnectionProcessConnectionSelector
+        """
+        super().__init__(connection_selector)
+        self._states = states
+
+    def _filter_and_add_repsonse(self, x, y, p, cpu_data):
+        state = CPUState(cpu_data[6])
+        if state not in self._states:
+            self._cpu_infos.append(CPUInfo(x, y, p, cpu_data))

--- a/spinnman/processes/get_exclude_cpu_info_process.py
+++ b/spinnman/processes/get_exclude_cpu_info_process.py
@@ -33,4 +33,4 @@ class GetExcludeCPUInfoProcess(GetCPUInfoProcess):
     def _filter_and_add_repsonse(self, x, y, p, cpu_data):
         state = CPUState(cpu_data[6])
         if state not in self._states:
-            self._cpu_infos.append(CPUInfo(x, y, p, cpu_data))
+            self._cpu_infos.add_info(CPUInfo(x, y, p, cpu_data))

--- a/spinnman/processes/get_include_cpu_info_process.py
+++ b/spinnman/processes/get_include_cpu_info_process.py
@@ -33,4 +33,4 @@ class GetIncludeCPUInfoProcess(GetCPUInfoProcess):
     def _filter_and_add_repsonse(self, x, y, p, cpu_data):
         state = CPUState(cpu_data[6])
         if state in self._states:
-            self._cpu_infos.append(CPUInfo(x, y, p, cpu_data))
+            self._cpu_infos.add_info(CPUInfo(x, y, p, cpu_data))

--- a/spinnman/processes/get_include_cpu_info_process.py
+++ b/spinnman/processes/get_include_cpu_info_process.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2015 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spinnman.model import CPUInfo
+from spinnman.model.enums import CPUState
+from .get_cpu_info_process import GetCPUInfoProcess
+
+
+class GetIncludeCPUInfoProcess(GetCPUInfoProcess):
+    __slots__ = [
+        "_states"]
+
+    def __init__(self, connection_selector, states):
+        """
+        :param connection_selector:
+        :type connection_selector:
+            AbstractMultiConnectionProcessConnectionSelector
+        """
+        super().__init__(connection_selector)
+        self._states = states
+
+    def _filter_and_add_repsonse(self, x, y, p, cpu_data):
+        state = CPUState(cpu_data[6])
+        if state in self._states:
+            self._cpu_infos.append(CPUInfo(x, y, p, cpu_data))

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -44,7 +44,7 @@ from spinnman.exceptions import (
     SpinnmanTimeoutException, SpinnmanGenericProcessException,
     SpinnmanUnexpectedResponseCodeException,
     SpiNNManCoresNotInStateException)
-from spinnman.model import CPUInfos, DiagnosticFilter, MachineDimensions
+from spinnman.model import DiagnosticFilter, MachineDimensions
 from spinnman.model.enums import CPUState
 from spinnman.messages.scp.impl.get_chip_info import GetChipInfo
 from spinnman.messages.spinnaker_boot import (
@@ -912,7 +912,7 @@ class Transceiver(AbstractContextManager):
             cores on all of the chips on the board are obtained.
         :return: An iterable of the CPU information for the selected cores, or
             all cores if core_subsets is not specified
-        :rtype: CPUInfos
+        :rtype: ~spinnman.model.CPUInfos
         :raise SpinnmanIOException:
             If there is an error communicating with the board
         :raise SpinnmanInvalidPacketException:
@@ -1211,7 +1211,6 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        a = self.get_cpu_infos(states=state)
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         response = process.execute(CountState(app_id, state))
         return response.count  # pylint: disable=no-member
@@ -2052,7 +2051,7 @@ class Transceiver(AbstractContextManager):
         """
         Get a string indicating the status of the given cores.
 
-        :param CPUInfos cpu_infos: A CPUInfos objects
+        :param ~spinnman.model.CPUInfos cpu_infos: A CPUInfos objects
         :rtype: str
         """
         break_down = "\n"

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -2015,7 +2015,7 @@ class Transceiver(AbstractContextManager):
                 # do a full check if required
                 tries += 1
                 if tries >= counts_between_full_check:
-                    cores_in_state = self.self.get_cpu_infos(
+                    cores_in_state = self.get_cpu_infos(
                         all_core_subsets, cpu_states, True)
                     processors_ready = len(cores_in_state)
                     tries = 0

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -910,8 +910,14 @@ class Transceiver(AbstractContextManager):
             A set of chips and cores from which to get the
             information. If not specified, the information from all of the
             cores on all of the chips on the board are obtained.
-        :return: An iterable of the CPU information for the selected cores, or
-            all cores if core_subsets is not specified
+        :param states: The state or states to filter on (if any)
+        :type states: None, CPUState or collection(CPUState)
+        :param bool include:
+            If True includes only infos in the requested state(s).
+            If False includes only infos NOT in the requested state(s).
+            Ignored if states is None.
+        :return: The CPU information for the selected cores and States, or
+            all cores/states  if core_subsets/states is not specified
         :rtype: ~spinnman.model.CPUInfos
         :raise SpinnmanIOException:
             If there is an error communicating with the board

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2014 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from spinnman.config_setup import unittest_setup
+from spinnman.model import CPUInfo, CPUInfos
+from spinnman.model.enums.cpu_state import CPUState
+
+
+class TestCpuInfos(unittest.TestCase):
+
+    def setUp(self):
+        unittest_setup()
+
+    def make_info_data(self, physical_cpu_id, state):
+        registers = b'@\x00\x07\x08\xff\x00\x00\x00\x00\x00\x80\x00\xad\x00' \
+                    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+                    b'\x00\x00\x00\x00\x00'
+        time = 1687857627
+        application_name = b'scamp-3\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        iobuff_address = 197634
+        return (registers, 0, 0, 0, 0, physical_cpu_id, state.value, 0, 0, 0,
+                0, 0, 0, 0, 0, time, application_name, iobuff_address, 0, 0,
+                0, 0, 0)
+
+    def test_cpu_infos(self):
+        infos = CPUInfos()
+
+        info = CPUInfo(0, 0, 1, self.make_info_data(5, CPUState.RUNNING))
+        infos.add_info(info)
+        info = CPUInfo(0, 0, 2, self.make_info_data(6, CPUState.FINISHED))
+        infos.add_info(info)
+        info = CPUInfo(1, 0, 1, self.make_info_data(7, CPUState.FINISHED))
+        infos.add_info(info)
+
+        self.assertEqual(
+            "['0, 0, 1 (ph: 5)', '0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)']",
+            str(infos))
+
+        finished = infos.infos_for_state(CPUState.FINISHED)
+        self.assertEqual(
+            "['0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)']", str(finished))
+        self.assertTrue(finished)
+
+        idle = infos.infos_for_state(CPUState.IDLE)
+        self.assertFalse(idle)
+
+        info = infos.get_cpu_info(0, 0, 2)
+        self.assertEqual(
+            "0:0:02 (06) FINISHED           scamp-3            0", str(info))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -112,7 +112,7 @@ class TestTransceiver(unittest.TestCase):
 
             assert trans.is_connected()
             print(trans.get_scamp_version())
-            print(trans.get_cpu_information())
+            print(trans.get_cpu_infos())
 
     def test_boot_board(self):
         board_config.set_up_remote_board()


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/SpiNNMan/issues/334

merges Transceiver methods
- get_cpu_information
- get_cores_in_state
- get_cores_not_in_state

Into
- get_cpu_infos
- Which takes optional states and include parameters and  returns a CPUInfos object.

Uses two Extensions of GetCPUInfoProcess to do filtering before creating a CPUInfo object
This required moving the INFO_PATTERN out of CPUInfo

CPUInfos has a new "infos_for_state" so that if Multiple Infos are needed they are read once of the machine and then split up

The get_cpu_information method name was changed as it return has changed. 
Transceiver,.get_cpu_information_from_core method not renamed as it kept its params and returned object.

Must be done at the same time as:

tested by: (Do not merge as it turned Java off to generate more core info calls)