### PR TITLE
Users

### DIFF
--- a/spinnman/constants.py
+++ b/spinnman/constants.py
@@ -58,16 +58,13 @@ CPU_INFO_OFFSET = 0xe5007000
 CPU_INFO_BYTES = 128
 
 #: The address at which user0 register starts
-CPU_USER_0_START_ADDRESS = 112
+CPU_USER_START_ADDRESS = 112
 
-#: The address at which user1 register starts
-CPU_USER_1_START_ADDRESS = 116
+# The number of bytes the user start address moves each time
+CPU_USER_OFFSET = 4
 
-#: The address at which user2 register starts
-CPU_USER_2_START_ADDRESS = 120
-
-#: The address at which user3 register starts
-CPU_USER_3_START_ADDRESS = 124
+# The largest user number
+CPU_MAX_USER = 3
 
 #: The address at which the iobuf address starts
 CPU_IOBUF_ADDRESS_OFFSET = 88

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -31,8 +31,7 @@ from spinn_machine import CoreSubsets
 from spinn_machine.spinnaker_triad_geometry import SpiNNakerTriadGeometry
 from spinnman.constants import (
     BMP_POST_POWER_ON_SLEEP_TIME, BMP_POWER_ON_TIMEOUT, BMP_TIMEOUT,
-    CPU_USER_0_START_ADDRESS, CPU_USER_1_START_ADDRESS,
-    CPU_USER_2_START_ADDRESS, CPU_USER_3_START_ADDRESS,
+    CPU_MAX_USER, CPU_USER_OFFSET, CPU_USER_START_ADDRESS,
     IPTAG_TIME_OUT_WAIT_TIMES, SCP_SCAMP_PORT, SYSTEM_VARIABLE_BASE_ADDRESS,
     UDP_BOOT_CONNECTION_DEFAULT_PORT, NO_ROUTER_DIAGNOSTIC_FILTERS,
     ROUTER_REGISTER_BASE_ADDRESS, ROUTER_DEFAULT_FILTERS_MAX_POSITION,
@@ -949,7 +948,7 @@ class Transceiver(AbstractContextManager):
             self.read_memory(x, y, addr, data_item.data_type.value))[0]
 
     @staticmethod
-    def get_user_0_register_address_from_core(p):
+    def __get_user_register_address_from_core(user, p):
         """
         Get the address of user 0 for a given processor on the board.
 
@@ -957,20 +956,26 @@ class Transceiver(AbstractContextManager):
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
+        :param int user: The user number to get the address for
         :param int p: The ID of the processor to get the user 0 address from
         :return: The address for user 0 register for this processor
         :rtype: int
         """
-        return get_vcpu_address(p) + CPU_USER_0_START_ADDRESS
+        if user < 0 or user > CPU_MAX_USER:
+            raise ValueError(
+                f"Incorrect user number {user}")
+        return (get_vcpu_address(p) + CPU_USER_START_ADDRESS +
+                CPU_USER_OFFSET * user)
 
-    def read_user_0(self, x, y, p):
+    def read_user(self, user, x, y, p):
         """
-        Get the contents of the user_0 register for the given processor.
+        Get the contents of the this user register for the given processor.
 
         .. note::
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
+        :param int user: The user number to get the address for
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param int p: Virtual processor identifier on the chip
@@ -984,61 +989,8 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.get_user_0_register_address_from_core(p)
+        addr = self.__get_user_register_address_from_core(user, p)
         return self.read_word(x, y, addr)
-
-    def read_user_1(self, x, y, p):
-        """
-        Get the contents of the user_1 register for the given processor.
-
-        :param int x: X coordinate of the chip
-        :param int y: Y coordinate of the chip
-        :param int p: Virtual processor identifier on the chip
-        :rtype: int
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If x, y, p does not identify a valid processor
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
-        addr = self.get_user_1_register_address_from_core(p)
-        return self.read_word(x, y, addr)
-
-    @staticmethod
-    def get_user_1_register_address_from_core(p):
-        """
-        Get the address of user 1 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 1 address from
-        :return: The address for user 1 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_1_START_ADDRESS
-
-    @staticmethod
-    def get_user_2_register_address_from_core(p):
-        """
-        Get the address of user 2 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 2 address from
-        :return: The address for user 2 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_2_START_ADDRESS
-
-    @staticmethod
-    def get_user_3_register_address_from_core(p):
-        """
-        Get the address of user 3 for a given processor on the board.
-
-        :param int p: The ID of the processor to get the user 3 address from
-        :return: The address for user 3 register for this processor
-        :rtype: int
-        """
-        return get_vcpu_address(p) + CPU_USER_3_START_ADDRESS
 
     def get_cpu_information_from_core(self, x, y, p):
         """
@@ -1640,9 +1592,9 @@ class Transceiver(AbstractContextManager):
                 x, y, cpu, base_address, data, offset, n_bytes, get_sum)
         return n_bytes, chksum
 
-    def write_user_0(self, x, y, p, value):
+    def write_user(self, user, x, y, p, value):
         """
-        Write to the user_0 register for the given processor.
+        Write to the this user register for the given processor.
 
         .. note::
             Conventionally, user_0 usually holds the address of the table of
@@ -1661,27 +1613,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.get_user_0_register_address_from_core(p)
-        self.write_memory(x, y, addr, int(value))
-
-    def write_user_1(self, x, y, p, value):
-        """
-        Write to the user_1 register for the given processor.
-
-        :param int x: X coordinate of the chip
-        :param int y: Y coordinate of the chip
-        :param int p: Virtual processor identifier on the chip
-        :param int value: The value to write
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If x, y, p does not identify a valid processor
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
-        addr = self.get_user_1_register_address_from_core(p)
+        addr = self.__get_user_register_address_from_core(user, p)
         self.write_memory(x, y, addr, int(value))
 
     def write_neighbour_memory(self, x, y, link, base_address, data,

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -961,7 +961,7 @@ class Transceiver(AbstractContextManager):
             self.read_memory(x, y, addr, data_item.data_type.value))[0]
 
     @staticmethod
-    def __get_user_register_address_from_core(user, p):
+    def __get_user_register_address_from_core(p, user):
         """
         Get the address of user 0 for a given processor on the board.
 
@@ -969,8 +969,8 @@ class Transceiver(AbstractContextManager):
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
-        :param int user: The user number to get the address for
         :param int p: The ID of the processor to get the user 0 address from
+        :param int user: The user number to get the address for
         :return: The address for user 0 register for this processor
         :rtype: int
         """
@@ -980,7 +980,7 @@ class Transceiver(AbstractContextManager):
         return (get_vcpu_address(p) + CPU_USER_START_ADDRESS +
                 CPU_USER_OFFSET * user)
 
-    def read_user(self, user, x, y, p):
+    def read_user(self, x, y, p, user):
         """
         Get the contents of the this user register for the given processor.
 
@@ -988,10 +988,10 @@ class Transceiver(AbstractContextManager):
             Conventionally, user_0 usually holds the address of the table of
             memory regions.
 
-        :param int user: The user number to get the address for
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param int p: Virtual processor identifier on the chip
+        :param int user: The user number to read data for
         :rtype: int
         :raise SpinnmanIOException:
             If there is an error communicating with the board
@@ -1002,7 +1002,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.__get_user_register_address_from_core(user, p)
+        addr = self.__get_user_register_address_from_core(p, user)
         return self.read_word(x, y, addr)
 
     def get_cpu_information_from_core(self, x, y, p):
@@ -1605,7 +1605,7 @@ class Transceiver(AbstractContextManager):
                 x, y, cpu, base_address, data, offset, n_bytes, get_sum)
         return n_bytes, chksum
 
-    def write_user(self, user, x, y, p, value):
+    def write_user(self, x, y, p, value, user):
         """
         Write to the this user register for the given processor.
 
@@ -1616,6 +1616,7 @@ class Transceiver(AbstractContextManager):
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param int p: Virtual processor identifier on the chip
+        :param int user: The user number of write data for
         :param int value: The value to write
         :raise SpinnmanIOException:
             If there is an error communicating with the board
@@ -1626,7 +1627,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        addr = self.__get_user_register_address_from_core(user, p)
+        addr = self.__get_user_register_address_from_core(p, user)
         self.write_memory(x, y, addr, int(value))
 
     def write_neighbour_memory(self, x, y, link, base_address, data,

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1605,7 +1605,7 @@ class Transceiver(AbstractContextManager):
                 x, y, cpu, base_address, data, offset, n_bytes, get_sum)
         return n_bytes, chksum
 
-    def write_user(self, x, y, p, value, user):
+    def write_user(self, x, y, p, user, value):
         """
         Write to the this user register for the given processor.
 


### PR DESCRIPTION
Reduces the number of exposed Transceiver methods by

combining read_user_0 and read_user_1
combining write_user_0  with 1, 2 and 3
combining get_user_0_register_address_from_core with 1, 2 and 3

All external calls can be routed through read_user and write_user so get_user_register_address_from_core made double underscore

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1084
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1366

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/215



