### PR TITLE
protect methods

### DIFF
--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -585,7 +585,7 @@ class ExtendedTransceiver(Transceiver):
             return process.read_link_memory(
                 x, y, cpu, link, base_address, length)
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise
 
     def _get_next_nearest_neighbour_id(self):
@@ -689,7 +689,7 @@ class ExtendedTransceiver(Transceiver):
             process = SendSingleCommandProcess(self._scamp_connection_selector)
             process.execute(SetLED(x, y, cpu, led_states))
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise
 
     def free_sdram(self, x, y, base_address, app_id):
@@ -710,7 +710,7 @@ class ExtendedTransceiver(Transceiver):
             process = DeAllocSDRAMProcess(self._scamp_connection_selector)
             process.de_alloc_sdram(x, y, app_id, base_address)
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise
 
     def free_sdram_by_app_id(self, x, y, app_id):
@@ -735,7 +735,7 @@ class ExtendedTransceiver(Transceiver):
             process.de_alloc_sdram(x, y, app_id)
             return process.no_blocks_freed
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise
 
     def get_router_diagnostic_filter(self, x, y, position):
@@ -776,7 +776,7 @@ class ExtendedTransceiver(Transceiver):
                 response.data, response.offset)[0])
             # pylint: disable=no-member
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise
 
     @property
@@ -826,5 +826,5 @@ class ExtendedTransceiver(Transceiver):
             process = GetHeapProcess(self._scamp_connection_selector)
             return process.get_heap((x, y), heap)
         except Exception:
-            logger.info(self.__where_is_xy(x, y))
+            logger.info(self._where_is_xy(x, y))
             raise

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -26,7 +26,6 @@ import time
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.log import FormatAdapter
-from spinn_utilities.logger_utils import warn_once
 from spinn_machine import CoreSubsets
 from spinnman.constants import (
     BMP_POST_POWER_ON_SLEEP_TIME, BMP_POWER_ON_TIMEOUT, BMP_TIMEOUT,

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -110,17 +110,17 @@ class TestTransceiver(unittest.TestCase):
         with transceiver.Transceiver(ver, connections=connections) as trans:
             SpiNNManDataWriter.mock().set_machine(trans.get_machine_details())
             if board_config.board_version in (2, 3):
-                assert trans.get_machine_dimensions().width == 2
-                assert trans.get_machine_dimensions().height == 2
+                assert trans._get_machine_dimensions().width == 2
+                assert trans._get_machine_dimensions().height == 2
             elif board_config.board_version in (4, 5):
-                assert trans.get_machine_dimensions().width == 8
-                assert trans.get_machine_dimensions().height == 8
+                assert trans._get_machine_dimensions().width == 8
+                assert trans._get_machine_dimensions().height == 8
             else:
-                size = trans.get_machine_dimensions()
+                size = trans._get_machine_dimensions()
                 print(f"Unknown board with size {size.width} x {size.height}")
 
             assert trans.is_connected()
-            print(trans.get_scamp_version())
+            print(trans._get_scamp_version())
             print(trans.get_cpu_infos())
 
     def test_boot_board(self):
@@ -128,7 +128,7 @@ class TestTransceiver(unittest.TestCase):
         with transceiver.create_transceiver_from_hostname(
                 board_config.remotehost, board_config.board_version) as trans:
             # self.assertFalse(trans.is_connected())
-            trans.boot_board()
+            trans._boot_board()
 
     def test_set_watch_dog(self):
         connections = []

--- a/unittests/test_version.py
+++ b/unittests/test_version.py
@@ -28,31 +28,31 @@ class Test(unittest.TestCase):
         unittest_setup()
 
     def test_version_same(self):
-        self.assertTrue(Transceiver.is_scamp_version_compabible((
+        self.assertTrue(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2])))
 
     def test_major_version_too_big(self):
-        self.assertFalse(Transceiver.is_scamp_version_compabible((
+        self.assertFalse(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0] + 1, 0, 0)))
 
     def test_major_version_too_small(self):
-        self.assertFalse(Transceiver.is_scamp_version_compabible((
+        self.assertFalse(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0] - 1, 0, 0)))
 
     def test_minor_version_bigger(self):
-        self.assertTrue(Transceiver.is_scamp_version_compabible((
+        self.assertTrue(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1] + 1, _SCAMP_VERSION[2])))
 
     def test_minor_version_smaller(self):
-        self.assertFalse(Transceiver.is_scamp_version_compabible((
+        self.assertFalse(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1] - 1, _SCAMP_VERSION[2])))
 
     def test_patch_version_bigger(self):
-        self.assertTrue(Transceiver.is_scamp_version_compabible((
+        self.assertTrue(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2] + 1)))
 
     def test_patch_version_smaller(self):
-        self.assertFalse(Transceiver.is_scamp_version_compabible((
+        self.assertFalse(Transceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2] - 1)))
 
     def test_compare_versions(self):


### PR DESCRIPTION
this pr changed the protection single / double under score of some Transceiver methods.

Only methods used outside of the Transceiver and its unittets are without underscore

Support methods used in various places are single underscore

Support methods use exactly once. are double underscore
IE the could be inlined. but are kept separate purely for code readability


removal of bmp_connection is a leftover from https://github.com/SpiNNakerManchester/SpiNNMan/pull/345 where it was moved to ExtendedTransceiver

Tested by
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/extended/3/pipeline/