### PR TITLE
No longer support a different bmp per frame and cabinet

### DIFF
--- a/spinnman/board_test_configuration.py
+++ b/spinnman/board_test_configuration.py
@@ -57,8 +57,7 @@ class BoardTestConfiguration(object):
         if self.bmp_names == "None":
             self.bmp_names = None
         else:
-            self.bmp_names = BMPConnectionData(
-                0, 0, self.bmp_names, [0], None)
+            self.bmp_names = BMPConnectionData(self.bmp_names, [0], None)
         self.auto_detect_bmp = \
             self._config.getboolean("Machine", "auto_detect_bmp")
         self.localport = _PORT

--- a/spinnman/board_test_configuration.py
+++ b/spinnman/board_test_configuration.py
@@ -57,8 +57,8 @@ class BoardTestConfiguration(object):
         if self.bmp_names == "None":
             self.bmp_names = None
         else:
-            self.bmp_names = [BMPConnectionData(
-                0, 0, self.bmp_names, [0], None)]
+            self.bmp_names = BMPConnectionData(
+                0, 0, self.bmp_names, [0], None)
         self.auto_detect_bmp = \
             self._config.getboolean("Machine", "auto_detect_bmp")
         self.localport = _PORT

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -450,8 +450,7 @@ class ExtendedTransceiver(Transceiver):
         """
         warn_once(logger, "The set_led method is deprecated and "
                   "untested due to no known use.")
-        process = SendSingleCommandProcess(
-            self._bmp_connection(cabinet, frame))
+        process = SendSingleCommandProcess(self._bmp_connection_selector)
         process.execute(BMPSetLed(led, action, board))
 
     def read_adc_data(self, board, cabinet, frame):
@@ -471,8 +470,7 @@ class ExtendedTransceiver(Transceiver):
         """
         warn_once(logger, "The read_adc_data method is deprecated and "
                   "untested due to no known use.")
-        process = SendSingleCommandProcess(
-            self._bmp_connection(cabinet, frame))
+        process = SendSingleCommandProcess(self._bmp_connection_selector)
         response = process.execute(ReadADC(board))
         return response.adc_info  # pylint: disable=no-member
 
@@ -792,25 +790,11 @@ class ExtendedTransceiver(Transceiver):
         warn_once(logger, "The number_of_boards_located method is deprecated "
                           "and likely to be removed.")
         boards = 0
-        for bmp_connection in self._bmp_connections:
-            boards += len(bmp_connection.boards)
+        if self._bmp_connection:
+            boards += len(self._bmp_connection.boards)
 
         # if no BMPs are available, then there's still at least one board
         return max(1, boards)
-
-    @property
-    def bmp_connection(self):
-        """
-        The BMP connections.
-
-        .. warning::
-            This property is currently deprecated and likely to be removed.
-
-        :rtype: dict(tuple(int,int),MostDirectConnectionSelector)
-        """
-        warn_once(logger, "The bmp_connection property is deprecated and "
-                  "likely to be removed.")
-        return self._bmp_connection_selectors
 
     def get_heap(self, x, y, heap=SystemVariableDefinition.sdram_heap_address):
         """

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -427,7 +427,7 @@ class ExtendedTransceiver(Transceiver):
         # Send a signal telling the application to start
         self.send_signal(app_id, Signal.START)
 
-    def set_led(self, led, action, board, cabinet, frame):
+    def set_led(self, led, action, board):
         """
         Set the LED state of a board in the machine.
 
@@ -445,15 +445,13 @@ class ExtendedTransceiver(Transceiver):
             also be an iterable of multiple boards (in the same frame). The
             command will actually be sent to the first board in the iterable.
         :type board: int or iterable(int)
-        :param int cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         """
         warn_once(logger, "The set_led method is deprecated and "
                   "untested due to no known use.")
         process = SendSingleCommandProcess(self._bmp_connection_selector)
         process.execute(BMPSetLed(led, action, board))
 
-    def read_adc_data(self, board, cabinet, frame):
+    def read_adc_data(self, board):
         """
         Read the BMP ADC data.
 
@@ -462,8 +460,6 @@ class ExtendedTransceiver(Transceiver):
             known use. Same functionality provided by ybug and bmpc.
             Retained in case needed for hardware debugging.
 
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the ADC data from
         :return: the FPGA's ADC data object
         :rtype: ADCInfo

--- a/spinnman/model/bmp_connection_data.py
+++ b/spinnman/model/bmp_connection_data.py
@@ -19,15 +19,11 @@ class BMPConnectionData(object):
     """
     __slots__ = [
         "_boards",
-        "_cabinet",
-        "_frame",
         "_ip_address",
         "_port_num"]
 
-    def __init__(self, cabinet, frame, ip_address, boards, port_num):
+    def __init__(self, ip_address, boards, port_num):
         # pylint: disable=too-many-arguments
-        self._cabinet = cabinet
-        self._frame = frame
         self._ip_address = ip_address
         self._boards = boards
         self._port_num = port_num
@@ -39,7 +35,7 @@ class BMPConnectionData(object):
 
         :rtype: int
         """
-        return self._cabinet
+        return 0
 
     @property
     def frame(self):
@@ -48,7 +44,7 @@ class BMPConnectionData(object):
 
         :rtype: int
         """
-        return self._frame
+        return 0
 
     @property
     def ip_address(self):
@@ -78,7 +74,7 @@ class BMPConnectionData(object):
         return self._port_num
 
     def __str__(self):
-        return (f"{self._cabinet}:{self._frame}:{self._ip_address}:"
+        return (f"{self._ip_address}:"
                 f"{self._boards}:{self._port_num}")
 
     def __repr__(self):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1085,15 +1085,11 @@ class Transceiver(AbstractContextManager):
         self.power_on(self._bmp_connection.boards)
         return True
 
-    def power_on(self, boards=0, cabinet=0, frame=0):
+    def power_on(self, boards=0):
         """
         Power on a set of boards in the machine.
 
         :param int boards: The board or boards to power on
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
         self._power(PowerCommand.POWER_ON, boards)
 
@@ -1111,28 +1107,20 @@ class Transceiver(AbstractContextManager):
         self.power_off(self._bmp_connection.boards)
         return True
 
-    def power_off(self, boards=0, cabinet=0, frame=0):
+    def power_off(self, boards=0):
         """
         Power off a set of boards in the machine.
 
         :param int boards: The board or boards to power off
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
         self._power(PowerCommand.POWER_OFF, boards)
 
-    def _power(self, power_command, boards=0, cabinet=0, frame=0):
+    def _power(self, power_command, boards=0):
         """
         Send a power request to the machine.
 
         :param PowerCommand power_command: The power command to send
         :param boards: The board or boards to send the command to
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
         connection_selector = self._bmp_connection_selector
         timeout = (
@@ -1148,7 +1136,7 @@ class Transceiver(AbstractContextManager):
         if not self._machine_off:
             time.sleep(BMP_POST_POWER_ON_SLEEP_TIME)
 
-    def read_fpga_register(self, fpga_num, register, cabinet, frame, board):
+    def read_fpga_register(self, fpga_num, register, board):
         """
         Read a register on a FPGA of a board. The meaning of the
         register's contents will depend on the FPGA's configuration.
@@ -1157,8 +1145,6 @@ class Transceiver(AbstractContextManager):
         :param int register:
             Register address to read to (will be rounded down to
             the nearest 32-bit word boundary).
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the FPGA register from
         :return: the register data
         :rtype: int
@@ -1169,8 +1155,7 @@ class Transceiver(AbstractContextManager):
             ReadFPGARegister(fpga_num, register, board))
         return response.fpga_register  # pylint: disable=no-member
 
-    def write_fpga_register(self, fpga_num, register, value, cabinet, frame,
-                            board):
+    def write_fpga_register(self, fpga_num, register, value, board):
         """
         Write a register on a FPGA of a board. The meaning of setting the
         register's contents will depend on the FPGA's configuration.
@@ -1180,20 +1165,16 @@ class Transceiver(AbstractContextManager):
             Register address to read to (will be rounded down to
             the nearest 32-bit word boundary).
         :param int value: the value to write into the FPGA register
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to write the FPGA register to
         """
         process = SendSingleCommandProcess(self._bmp_connection_selector)
         process.execute(
             WriteFPGARegister(fpga_num, register, value, board))
 
-    def read_bmp_version(self, board, cabinet, frame):
+    def read_bmp_version(self, board):
         """
         Read the BMP version.
 
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the data from
         :return: the sver from the BMP
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1963,7 +1963,7 @@ class Transceiver(AbstractContextManager):
         """
         Close the transceiver and any threads that are running.
         """
-        if self._bmp_connections:
+        if self._bmp_connection:
             if get_config_bool("Machine", "turn_off_machine"):
                 self.power_off_machine()
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -109,7 +109,7 @@ def create_transceiver_from_hostname(
     :param int version: the type of SpiNNaker board used within the SpiNNaker
         machine being used. If a Spinn-5 board, then the version will be 5,
         Spinn-3 would equal 3 and so on.
-    :param list(BMPConnectionData) bmp_connection_data:
+    :param BMPConnectionData bmp_connection_data:
         the details of the BMP connections used to boot multi-board systems
     :param bool auto_detect_bmp:
         ``True`` if the BMP of version 4 or 5 boards should be
@@ -136,17 +136,15 @@ def create_transceiver_from_hostname(
     # final value of the IP address
     if (version >= 4 and auto_detect_bmp is True and
             (bmp_connection_data is None or not bmp_connection_data)):
-        bmp_connection_data = [
-            work_out_bmp_from_machine_details(hostname, number_of_boards)]
+        bmp_connection_data = work_out_bmp_from_machine_details(
+            hostname, number_of_boards)
 
     # handle BMP connections
     if bmp_connection_data is not None:
-        bmp_ip_list = list()
-        for conn_data in bmp_connection_data:
-            bmp_connection = BMPConnection(conn_data)
-            connections.append(bmp_connection)
-            bmp_ip_list.append(bmp_connection.remote_ip_address)
-        logger.info("Transceiver using BMPs: {}", bmp_ip_list)
+        bmp_connection = BMPConnection(bmp_connection_data)
+        connections.append(bmp_connection)
+        logger.info("Transceiver using BMP: {}",
+                    bmp_connection.remote_ip_address)
 
     connections.append(SCAMPConnection(remote_host=hostname))
 

--- a/spinnman/utilities/utility_functions.py
+++ b/spinnman/utilities/utility_functions.py
@@ -50,7 +50,7 @@ def work_out_bmp_from_machine_details(hostname, number_of_boards):
         board_range = range(number_of_boards)
 
     # Assume a single board with no cabinet or frame specified
-    return BMPConnectionData(cabinet=0, frame=0, ip_address=bmp_ip_address,
+    return BMPConnectionData(ip_address=bmp_ip_address,
                              boards=board_range, port_num=SCP_SCAMP_PORT)
 
 


### PR DESCRIPTION
the transceiver code was designed to allow a different BMP per frame and cabinet.

This was however never used. In Frame and cabinet where always 0

This pr removes that.
So a Transceiver now has a single bmp connection and therefor a single bmp conncetion selector

Must be done at the same time as:


tested by:
