### PR TITLE
No frames3

### DIFF
--- a/spinnman/board_test_configuration.py
+++ b/spinnman/board_test_configuration.py
@@ -57,8 +57,7 @@ class BoardTestConfiguration(object):
         if self.bmp_names == "None":
             self.bmp_names = None
         else:
-            self.bmp_names = [BMPConnectionData(
-                0, 0, self.bmp_names, [0], None)]
+            self.bmp_names = [BMPConnectionData(self.bmp_names, [0], None)]
         self.auto_detect_bmp = \
             self._config.getboolean("Machine", "auto_detect_bmp")
         self.localport = _PORT

--- a/spinnman/connections/udp_packet_connections/bmp_connection.py
+++ b/spinnman/connections/udp_packet_connections/bmp_connection.py
@@ -29,9 +29,7 @@ class BMPConnection(UDPConnection, AbstractSCPConnection):
     A BMP connection which supports queries to the BMP of a SpiNNaker machine.
     """
     __slots__ = [
-        "_boards",
-        "_cabinet",
-        "_frame"]
+        "_boards"]
 
     def __init__(self, connection_data):
         """
@@ -42,27 +40,7 @@ class BMPConnection(UDPConnection, AbstractSCPConnection):
             else connection_data.port_num
         super().__init__(
             remote_host=connection_data.ip_address, remote_port=port)
-        self._cabinet = connection_data.cabinet
-        self._frame = connection_data.frame
         self._boards = connection_data.boards
-
-    @property
-    def cabinet(self):
-        """
-        The cabinet ID of the BMP.
-
-        :rtype: int
-        """
-        return self._cabinet
-
-    @property
-    def frame(self):
-        """
-        The frame ID of the BMP.
-
-        :rtype: int
-        """
-        return self._frame
 
     @property
     def boards(self):

--- a/spinnman/connections/udp_packet_connections/bmp_connection.py
+++ b/spinnman/connections/udp_packet_connections/bmp_connection.py
@@ -84,7 +84,7 @@ class BMPConnection(UDPConnection, AbstractSCPConnection):
 
     def __repr__(self):
         return (
-            f"BMPConnection(cabinet={self._cabinet}, frame={self._frame}, "
+            f"BMPConnection("
             f"boards={self._boards}, local_host={self.local_ip_address}, "
             f"local_port={self.local_port}, "
             f"remote_host={self.remote_ip_address}, "

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -427,7 +427,7 @@ class ExtendedTransceiver(Transceiver):
         # Send a signal telling the application to start
         self.send_signal(app_id, Signal.START)
 
-    def set_led(self, led, action, board, cabinet, frame):
+    def set_led(self, led, action, board):
         """
         Set the LED state of a board in the machine.
 
@@ -442,18 +442,16 @@ class ExtendedTransceiver(Transceiver):
         :param LEDAction action:
             State to set the LED to, either on, off or toggle
         :param board: Specifies the board to control the LEDs of. This may
-            also be an iterable of multiple boards (in the same frame). The
+            also be an iterable of multiple boards. The
             command will actually be sent to the first board in the iterable.
         :type board: int or iterable(int)
-        :param int cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         """
         warn_once(logger, "The set_led method is deprecated and "
                   "untested due to no known use.")
         process = SendSingleCommandProcess(self._bmp_selector)
         process.execute(BMPSetLed(led, action, board))
 
-    def read_adc_data(self, board, cabinet, frame):
+    def read_adc_data(self, board):
         """
         Read the BMP ADC data.
 
@@ -462,8 +460,6 @@ class ExtendedTransceiver(Transceiver):
             known use. Same functionality provided by ybug and bmpc.
             Retained in case needed for hardware debugging.
 
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the ADC data from
         :return: the FPGA's ADC data object
         :rtype: ADCInfo

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -785,12 +785,11 @@ class ExtendedTransceiver(Transceiver):
         """
         warn_once(logger, "The number_of_boards_located method is deprecated "
                           "and likely to be removed.")
-        boards = 0
-        for bmp_connection in self._bmp_connections:
-            boards += len(bmp_connection.boards)
-
-        # if no BMPs are available, then there's still at least one board
-        return max(1, boards)
+        if self._bmp_connection is not None:
+            return max(1, len(self._bmp_connection.boards))
+        else:
+            # if no BMPs are available, then there's still at least one board
+            return 1
 
     def get_heap(self, x, y, heap=SystemVariableDefinition.sdram_heap_address):
         """

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -450,8 +450,7 @@ class ExtendedTransceiver(Transceiver):
         """
         warn_once(logger, "The set_led method is deprecated and "
                   "untested due to no known use.")
-        process = SendSingleCommandProcess(
-            self._bmp_connection(cabinet, frame))
+        process = SendSingleCommandProcess(self._bmp_selector)
         process.execute(BMPSetLed(led, action, board))
 
     def read_adc_data(self, board, cabinet, frame):
@@ -471,8 +470,7 @@ class ExtendedTransceiver(Transceiver):
         """
         warn_once(logger, "The read_adc_data method is deprecated and "
                   "untested due to no known use.")
-        process = SendSingleCommandProcess(
-            self._bmp_connection(cabinet, frame))
+        process = SendSingleCommandProcess(self._bmp_selector)
         response = process.execute(ReadADC(board))
         return response.adc_info  # pylint: disable=no-member
 
@@ -797,20 +795,6 @@ class ExtendedTransceiver(Transceiver):
 
         # if no BMPs are available, then there's still at least one board
         return max(1, boards)
-
-    @property
-    def bmp_connection(self):
-        """
-        The BMP connections.
-
-        .. warning::
-            This property is currently deprecated and likely to be removed.
-
-        :rtype: dict(tuple(int,int),MostDirectConnectionSelector)
-        """
-        warn_once(logger, "The bmp_connection property is deprecated and "
-                  "likely to be removed.")
-        return self._bmp_connection_selectors
 
     def get_heap(self, x, y, heap=SystemVariableDefinition.sdram_heap_address):
         """

--- a/spinnman/model/bmp_connection_data.py
+++ b/spinnman/model/bmp_connection_data.py
@@ -56,8 +56,7 @@ class BMPConnectionData(object):
         return self._port_num
 
     def __str__(self):
-        return (f"{self._cabinet}:{self._frame}:{self._ip_address}:"
-                f"{self._boards}:{self._port_num}")
+        return (f"{self._ip_address}:{self._boards}:{self._port_num}")
 
     def __repr__(self):
         return self.__str__()

--- a/spinnman/model/bmp_connection_data.py
+++ b/spinnman/model/bmp_connection_data.py
@@ -29,24 +29,6 @@ class BMPConnectionData(object):
         self._port_num = port_num
 
     @property
-    def cabinet(self):
-        """
-        The cabinet number.
-
-        :rtype: int
-        """
-        return self._cabinet
-
-    @property
-    def frame(self):
-        """
-        The frame number.
-
-        :rtype: int
-        """
-        return self._frame
-
-    @property
     def ip_address(self):
         """
         The IP address of the BMP.

--- a/spinnman/model/bmp_connection_data.py
+++ b/spinnman/model/bmp_connection_data.py
@@ -19,15 +19,11 @@ class BMPConnectionData(object):
     """
     __slots__ = [
         "_boards",
-        "_cabinet",
-        "_frame",
         "_ip_address",
         "_port_num"]
 
-    def __init__(self, cabinet, frame, ip_address, boards, port_num):
+    def __init__(self, ip_address, boards, port_num):
         # pylint: disable=too-many-arguments
-        self._cabinet = cabinet
-        self._frame = frame
         self._ip_address = ip_address
         self._boards = boards
         self._port_num = port_num

--- a/spinnman/spinnman.cfg
+++ b/spinnman/spinnman.cfg
@@ -13,12 +13,9 @@ report_waiting_logs = False
 turn_off_machine = False
 
 # format is:
-#     bmp_names     = <bmp_id>[:<bmp_id>]*
-#     <bmp_id>      = [[<cabinet_id>;]<frame_id>;]<host>[/(<board-range>|board_id[,board_id]*)]
+#     bmp_names     = <host>[/(<board-range>|board_id[,board_id]*)
 #     <board_range> = <board_id>-<board_id>
 # where:
-#     <cabinet_id> is the ID of a cabinet
-#     <frame_id> is the ID of a frame in a cabinet
 #     <host> is the hostname or IP address of the BMP
 #     <board_range> is a range of boards that the BMP can speak to
 #     <board_id> is the ID of a single board in a frame

--- a/spinnman/spinnman.cfg
+++ b/spinnman/spinnman.cfg
@@ -19,6 +19,7 @@ turn_off_machine = False
 #     <host> is the hostname or IP address of the BMP
 #     <board_range> is a range of boards that the BMP can speak to
 #     <board_id> is the ID of a single board in a frame
+# Note this no longer supports multiple host nor cabinet or frame
 bmp_names = None
 
 auto_detect_bmp = False

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1059,17 +1059,13 @@ class Transceiver(AbstractContextManager):
             self.power_on(bmp_connection.boards)
         return True
 
-    def power_on(self, boards=0, cabinet=0, frame=0):
+    def power_on(self, boards=0):
         """
         Power on a set of boards in the machine.
 
         :param int boards: The board or boards to power on
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
-        self._power(PowerCommand.POWER_ON, boards, cabinet, frame)
+        self._power(PowerCommand.POWER_ON, boards)
 
     def power_off_machine(self):
         """
@@ -1086,28 +1082,20 @@ class Transceiver(AbstractContextManager):
             self.power_off(bmp_connection.boards)
         return True
 
-    def power_off(self, boards=0, cabinet=0, frame=0):
+    def power_off(self, boards=0):
         """
         Power off a set of boards in the machine.
 
         :param int boards: The board or boards to power off
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
-        self._power(PowerCommand.POWER_OFF, boards, cabinet, frame)
+        self._power(PowerCommand.POWER_OFF, boards)
 
-    def _power(self, power_command, boards=0, cabinet=0, frame=0):
+    def _power(self, power_command, boards=0):
         """
         Send a power request to the machine.
 
         :param PowerCommand power_command: The power command to send
         :param boards: The board or boards to send the command to
-        :param int cabinet: the ID of the cabinet containing the frame, or 0
-            if the frame is not in a cabinet
-        :param int frame: the ID of the frame in the cabinet containing the
-            board(s), or 0 if the board is not in a frame
         """
         connection_selector = self._bmp_selector
         timeout = (
@@ -1124,7 +1112,7 @@ class Transceiver(AbstractContextManager):
             time.sleep(BMP_POST_POWER_ON_SLEEP_TIME)
 
     def read_fpga_register(
-            self, fpga_num, register, cabinet=0, frame=0, board=0):
+            self, fpga_num, register, board=0):
         """
         Read a register on a FPGA of a board. The meaning of the
         register's contents will depend on the FPGA's configuration.
@@ -1133,8 +1121,6 @@ class Transceiver(AbstractContextManager):
         :param int register:
             Register address to read to (will be rounded down to
             the nearest 32-bit word boundary).
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the FPGA register from
         :return: the register data
         :rtype: int
@@ -1144,8 +1130,7 @@ class Transceiver(AbstractContextManager):
             ReadFPGARegister(fpga_num, register, board))
         return response.fpga_register  # pylint: disable=no-member
 
-    def write_fpga_register(self, fpga_num, register, value,
-                            cabinet=0, frame=0, board=0):
+    def write_fpga_register(self, fpga_num, register, value, board=0):
         """
         Write a register on a FPGA of a board. The meaning of setting the
         register's contents will depend on the FPGA's configuration.
@@ -1155,20 +1140,16 @@ class Transceiver(AbstractContextManager):
             Register address to read to (will be rounded down to
             the nearest 32-bit word boundary).
         :param int value: the value to write into the FPGA register
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to write the FPGA register to
         """
         process = SendSingleCommandProcess(self._bmp_selector)
         process.execute(
             WriteFPGARegister(fpga_num, register, value, board))
 
-    def read_bmp_version(self, board, cabinet=0, frame=0):
+    def read_bmp_version(self, board):
         """
         Read the BMP version.
 
-        :param int cabinet: cabinet: the cabinet this is targeting
-        :param int frame: the frame this is targeting
         :param int board: which board to request the data from
         :return: the sver from the BMP
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1161,8 +1161,8 @@ class Transceiver(AbstractContextManager):
             ReadFPGARegister(fpga_num, register, board))
         return response.fpga_register  # pylint: disable=no-member
 
-    def write_fpga_register(self, fpga_num, register, value, cabinet, frame,
-                            board):
+    def write_fpga_register(self, fpga_num, register, value,
+                            cabinet=0, frame=0, board=0):
         """
         Write a register on a FPGA of a board. The meaning of setting the
         register's contents will depend on the FPGA's configuration.

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1139,7 +1139,8 @@ class Transceiver(AbstractContextManager):
         if not self._machine_off:
             time.sleep(BMP_POST_POWER_ON_SLEEP_TIME)
 
-    def read_fpga_register(self, fpga_num, register, cabinet, frame, board):
+    def read_fpga_register(
+            self, fpga_num, register, cabinet=0, frame=0, board=0):
         """
         Read a register on a FPGA of a board. The meaning of the
         register's contents will depend on the FPGA's configuration.

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -289,7 +289,7 @@ class Transceiver(AbstractContextManager):
             if isinstance(conn, BMPConnection):
                 # If it is a BMP conn, add it here
                 self._bmp_connections.append(conn)
-                self._bmp_connection_selectors[conn.cabinet, conn.frame] =\
+                self._bmp_connection_selectors[0, 0] =\
                     FixedConnectionSelector(conn)
             # Otherwise, check if it can send and receive SCP (talk to SCAMP)
             elif isinstance(conn, SCAMPConnection):
@@ -312,7 +312,7 @@ class Transceiver(AbstractContextManager):
             try:
                 version_info = self._get_scamp_version(
                     conn.chip_x, conn.chip_y,
-                    self._bmp_connection_selectors[conn.cabinet, conn.frame])
+                    self._bmp_connection_selectors[0, 0])
                 fail_version_name = version_info.name != _BMP_NAME
                 fail_version_num = \
                     version_info.version_number[0] not in _BMP_MAJOR_VERSIONS
@@ -1057,8 +1057,7 @@ class Transceiver(AbstractContextManager):
             logger.warning("No BMP connections, so can't power on")
             return False
         for bmp_connection in self._bmp_connections:
-            self.power_on(bmp_connection.boards, bmp_connection.cabinet,
-                          bmp_connection.frame)
+            self.power_on(bmp_connection.boards)
         return True
 
     def power_on(self, boards=0, cabinet=0, frame=0):
@@ -1085,8 +1084,7 @@ class Transceiver(AbstractContextManager):
             return False
         logger.info("Turning off machine")
         for bmp_connection in self._bmp_connections:
-            self.power_off(bmp_connection.boards, bmp_connection.cabinet,
-                           bmp_connection.frame)
+            self.power_off(bmp_connection.boards)
         return True
 
     def power_off(self, boards=0, cabinet=0, frame=0):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1181,7 +1181,7 @@ class Transceiver(AbstractContextManager):
         process.execute(
             WriteFPGARegister(fpga_num, register, value, board))
 
-    def read_bmp_version(self, board, cabinet, frame):
+    def read_bmp_version(self, board, cabinet=0, frame=0):
         """
         Read the BMP version.
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1105,10 +1105,11 @@ class Transceiver(AbstractContextManager):
         :param int frame:
         :rtype: FixedConnectionSelector
         """
-        key = (cabinet, frame)
+        assert (cabinet==frame==0)
+        key = (0, 0)
         if key not in self._bmp_connection_selectors:
             raise SpinnmanInvalidParameterException(
-                "cabinet and frame", f"{cabinet} and {frame}",
+                "cabinet and frame", f"{0} and {0}",
                 "Unknown combination")
         return self._bmp_connection_selectors[key]
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -109,7 +109,7 @@ def create_transceiver_from_hostname(
     :param int version: the type of SpiNNaker board used within the SpiNNaker
         machine being used. If a Spinn-5 board, then the version will be 5,
         Spinn-3 would equal 3 and so on.
-    :param list(BMPConnectionData) bmp_connection_data:
+    :param BMPConnectionData bmp_connection_data:
         the details of the BMP connections used to boot multi-board systems
     :param bool auto_detect_bmp:
         ``True`` if the BMP of version 4 or 5 boards should be
@@ -141,12 +141,10 @@ def create_transceiver_from_hostname(
 
     # handle BMP connections
     if bmp_connection_data is not None:
-        bmp_ip_list = list()
-        for conn_data in bmp_connection_data:
-            bmp_connection = BMPConnection(conn_data)
-            connections.append(bmp_connection)
-            bmp_ip_list.append(bmp_connection.remote_ip_address)
-        logger.info("Transceiver using BMPs: {}", bmp_ip_list)
+        bmp_connection = BMPConnection(bmp_connection_data)
+        connections.append(bmp_connection)
+        logger.info("Transceiver using BMP: {}",
+                    bmp_connection.remote_ip_address)
 
     connections.append(SCAMPConnection(remote_host=hostname))
 

--- a/spinnman/utilities/utility_functions.py
+++ b/spinnman/utilities/utility_functions.py
@@ -50,7 +50,7 @@ def work_out_bmp_from_machine_details(hostname, number_of_boards):
         board_range = range(number_of_boards)
 
     # Assume a single board with no cabinet or frame specified
-    return BMPConnectionData(cabinet=0, frame=0, ip_address=bmp_ip_address,
+    return BMPConnectionData(ip_address=bmp_ip_address,
                              boards=board_range, port_num=SCP_SCAMP_PORT)
 
 


### PR DESCRIPTION
alternative to https://github.com/SpiNNakerManchester/SpiNNMan/pull/349
That PR would not allow a merge for some weird reason and the spalloc_server test hung

the transceiver code was designed to allow a different BMP per frame and cabinet.

This was however never used. In Frame and cabinet where always 0

This pr removes that.
So a Transceiver now has a single bmp connection and therefor a single bmp conncetion selector

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1097
https://github.com/SpiNNakerManchester/spalloc_server/pull/90

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/222
