### PR TITLE
Version fix

### DIFF
--- a/quick_tests/quick_tests.py
+++ b/quick_tests/quick_tests.py
@@ -43,6 +43,7 @@ from spinnman.board_test_configuration import BoardTestConfiguration
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("spinnman.transceiver").setLevel(logging.DEBUG)
 
+unittest_setup()
 board_config = BoardTestConfiguration()
 board_config.set_up_remote_board()
 
@@ -352,7 +353,6 @@ def print_transceiver_tests(transceiver):
             print(heap_element)
 
 
-unittest_setup()
 with create_transceiver_from_hostname(
         board_config.remotehost, board_config.board_version,
         bmp_connection_data=board_config.bmp_names,

--- a/spinnman/board_test_configuration.cfg
+++ b/spinnman/board_test_configuration.cfg
@@ -1,9 +1,0 @@
-[Machine]
-machineName = spinn-4.cs.man.ac.uk
-bmp_names = spinn-4c.cs.man.ac.uk
-version = 5
-
-#machineName = 192.168.240.253
-#version = 2
-#bmp_names = None
-auto_detect_bmp = False

--- a/spinnman/board_test_configuration.py
+++ b/spinnman/board_test_configuration.py
@@ -15,7 +15,7 @@
 import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_utilities.ping import Ping
-from spinnman.model import BMPConnectionData
+# from spinnman.model import BMPConnectionData
 
 _LOCALHOST = "127.0.0.1"
 # Microsoft invalid IP address. For more details see:

--- a/spinnman/board_test_configuration.py
+++ b/spinnman/board_test_configuration.py
@@ -17,6 +17,7 @@ from contextlib import closing
 import os
 import socket
 import unittest
+from spinn_utilities.config_holder import set_config
 from spinn_utilities.ping import Ping
 from spinnman.model import BMPConnectionData
 
@@ -30,44 +31,45 @@ _PORT = 54321
 class BoardTestConfiguration(object):
 
     def __init__(self):
-        self.localhost = None
+        #self.localhost = None
         self.localport = None
         self.remotehost = None
         self.board_version = None
         self.bmp_names = None
         self.auto_detect_bmp = None
 
-        self._config = configparser.RawConfigParser()
-        config_file = os.path.join(
-            os.path.dirname(__file__), "board_test_configuration.cfg")
-        self._config.read(config_file)
-
     def set_up_local_virtual_board(self):
-        self.localhost = _LOCALHOST
+        #self.localhost = _LOCALHOST
         self.localport = _PORT
         self.remotehost = _LOCALHOST
-        self.board_version = self._config.getint("Machine", "version")
+        self.board_version = 5
 
     def set_up_remote_board(self):
-        self.remotehost = self._config.get("Machine", "machineName")
-        if not Ping.host_is_reachable(self.remotehost):
-            raise unittest.SkipTest("test board appears to be down")
-        self.board_version = self._config.getint("Machine", "version")
-        self.bmp_names = self._config.get("Machine", "bmp_names")
+        if Ping.host_is_reachable("192.168.240.253"):
+            self.remotehost = "192.168.240.253"
+            self.board_version = 3
+            set_config("Machine", "version", 3)
+            self.auto_detect_bmp = False
+        elif Ping.host_is_reachable("spinn-4.cs.man.ac.uk"):
+            self.remotehost = "spinn-4.cs.man.ac.uk"
+            self.board_version = 5
+            set_config("Machine", "version", 5)
+        elif Ping.host_is_reachable("192.168.240.1"):
+            self.remotehost = "192.168.240.1"
+            self.board_version = 5
+            set_config("Machine", "version", 5)
+        else:
+            raise unittest.SkipTest("None of the test boards reachable")
+
         if self.bmp_names == "None":
             self.bmp_names = None
         else:
+            # it always was None but this is what to do if not
             self.bmp_names = [BMPConnectionData(
                 0, 0, self.bmp_names, [0], None)]
-        self.auto_detect_bmp = \
-            self._config.getboolean("Machine", "auto_detect_bmp")
-        self.localport = _PORT
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as s:
-            s.connect((self.remotehost, _PORT))
-            self.localhost = s.getsockname()[0]
 
     def set_up_nonexistent_board(self):
         self.localhost = None
         self.localport = _PORT
         self.remotehost = _NOHOST
-        self.board_version = self._config.getint("Machine", "version")
+        self.board_version = None

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -21,8 +21,8 @@ import argparse
 from spinnman.transceiver import create_transceiver_from_hostname
 from spinn_machine import CoreSubsets, CoreSubset
 from spinnman.board_test_configuration import BoardTestConfiguration
+from spinnman.config_setup import unittest_setup
 from spinnman.model.enums import CPUState
-
 SCAMP_ID = 0
 IGNORED_IDS = {SCAMP_ID, 16}  # WHY 16?
 
@@ -104,6 +104,7 @@ def main(args):
     """
     Runs the script.
     """
+    unittest_setup()
     ap = argparse.ArgumentParser(
         description="Check the state of a SpiNNaker machine.")
     ap.add_argument(

--- a/unittests/connection_tests/test_udp_connection.py
+++ b/unittests/connection_tests/test_udp_connection.py
@@ -21,18 +21,18 @@ from spinnman.messages.scp.enums import SCPResult
 from spinnman.messages.scp.impl.get_version_response import GetVersionResponse
 from spinnman.board_test_configuration import BoardTestConfiguration
 
-board_config = BoardTestConfiguration()
 
 
 class TestUDPConnection(unittest.TestCase):
 
     def setUp(self):
         unittest_setup()
+        self.board_config = BoardTestConfiguration()
 
     def test_scp_version_request_and_response_board(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connection = SCAMPConnection(
-            remote_host=board_config.remotehost)
+            remote_host=self.board_config.remotehost)
         scp_req = GetVersion(0, 0, 0)
         scp_response = GetVersionResponse()
         connection.send_scp_request(scp_req)
@@ -43,18 +43,18 @@ class TestUDPConnection(unittest.TestCase):
             scp_response._scp_response_header._result, SCPResult.RC_OK)
 
     def test_scp_read_link_request_and_response_board(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connection = SCAMPConnection(
-            remote_host=board_config.remotehost)
+            remote_host=self.board_config.remotehost)
         scp_link = ReadLink(0, 0, 0, 0x70000000, 250)
         connection.send_scp_request(scp_link)
         result, _, _, _ = connection.receive_scp_response()
         self.assertEqual(result, SCPResult.RC_OK)
 
     def test_scp_read_memory_request_and_response_board(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connection = SCAMPConnection(
-            remote_host=board_config.remotehost)
+            remote_host=self.board_config.remotehost)
         scp_link = ReadMemory(0, 0, 0x70000000, 256)
         connection.send_scp_request(scp_link)
         result, _, _, _ = connection.receive_scp_response()
@@ -62,9 +62,9 @@ class TestUDPConnection(unittest.TestCase):
 
     def test_send_scp_request_to_nonexistent_host(self):
         with self.assertRaises(SpinnmanTimeoutException):
-            board_config.set_up_nonexistent_board()
+            self.board_config.set_up_nonexistent_board()
             connection = SCAMPConnection(
-                remote_host=board_config.remotehost)
+                remote_host=self.board_config.remotehost)
             scp = ReadMemory(0, 0, 0, 256)
             connection.send_scp_request(scp)
             _, _, _, _ = connection.receive_scp_response(2)

--- a/unittests/model_tests/test_iptag_model.py
+++ b/unittests/model_tests/test_iptag_model.py
@@ -17,7 +17,6 @@ from spinn_machine.tags import IPTag
 from spinnman.board_test_configuration import BoardTestConfiguration
 from spinnman.config_setup import unittest_setup
 
-board_config = BoardTestConfiguration()
 
 
 class TestIptag(unittest.TestCase):
@@ -26,6 +25,7 @@ class TestIptag(unittest.TestCase):
         unittest_setup()
 
     def test_new_iptag(self):
+        board_config = BoardTestConfiguration()
         board_config.set_up_remote_board()
         ip = "8.8.8.8"
         port = 1337

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -17,6 +17,7 @@ import struct
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
 from spinnman.config_setup import unittest_setup
+from spinnman.data import SpiNNManDataView
 from spinnman.data.spinnman_data_writer import SpiNNManDataWriter
 from spinnman.extended.extended_transceiver import ExtendedTransceiver
 from spinnman.transceiver import Transceiver
@@ -29,7 +30,6 @@ import spinnman.transceiver as transceiver
 import spinnman.extended.extended_transceiver as extended
 from spinnman.board_test_configuration import BoardTestConfiguration
 
-board_config = BoardTestConfiguration()
 ver = 5  # Guess?
 
 
@@ -41,7 +41,9 @@ class MockWriteTransceiver(Transceiver):
         self.written_memory = list()
 
     def get_machine_details(self):
-        return virtual_machine(8, 8)
+        version = SpiNNManDataView.get_machine_version()
+        width, height = version.board_shape
+        return virtual_machine(width, height)
 
     def _update_machine(self):
         self._machine = self.get_machine_details()
@@ -63,71 +65,70 @@ class MockExtendedTransceiver(MockWriteTransceiver, ExtendedTransceiver):
 
 class TestTransceiver(unittest.TestCase):
 
+
     def setUp(self):
         unittest_setup()
         set_config("Machine", "version", 5)
+        self.board_config = BoardTestConfiguration()
 
     def test_create_new_transceiver_to_board(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connections = list()
         connections.append(SCAMPConnection(
-            remote_host=board_config.remotehost))
+            remote_host=self.board_config.remotehost))
         trans = transceiver.Transceiver(ver, connections=connections)
         trans.close()
 
     def test_create_new_transceiver_one_connection(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connections = set()
         connections.add(SCAMPConnection(
-            remote_host=board_config.remotehost))
+            remote_host=self.board_config.remotehost))
         with extended.ExtendedTransceiver(
                 ver, connections=connections) as trans:
-            assert trans.get_connections() == connections
+            assert trans._all_connections == connections
 
     def test_create_new_transceiver_from_list_connections(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connections = list()
         connections.append(SCAMPConnection(
-            remote_host=board_config.remotehost))
-        board_config.set_up_local_virtual_board()
-        connections.append(BootConnection(
-            remote_host=board_config.remotehost))
+            remote_host=self.board_config.remotehost))
+        connections.append(BootConnection(remote_host="127.0.0.1"))
         with transceiver.Transceiver(ver, connections=connections) as trans:
-            instantiated_connections = trans.get_connections()
+            instantiated_connections = trans._all_connections
 
             for connection in connections:
                 assert connection in instantiated_connections
             # assert trans.get_connections() == connections
 
     def test_retrieving_machine_details(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         connections = list()
         connections.append(SCAMPConnection(
-            remote_host=board_config.remotehost))
-        board_config.set_up_local_virtual_board()
-        connections.append(BootConnection(
-            remote_host=board_config.remotehost))
+            remote_host=self.board_config.remotehost))
+        connections.append(BootConnection(remote_host="127.0.0.1"))
         with transceiver.Transceiver(ver, connections=connections) as trans:
             SpiNNManDataWriter.mock().set_machine(trans.get_machine_details())
-            if board_config.board_version in (2, 3):
+            if self.board_config.board_version in (2, 3):
                 assert trans._get_machine_dimensions().width == 2
                 assert trans._get_machine_dimensions().height == 2
-            elif board_config.board_version in (4, 5):
+            elif self.board_config.board_version in (4, 5):
                 assert trans._get_machine_dimensions().width == 8
                 assert trans._get_machine_dimensions().height == 8
             else:
                 size = trans._get_machine_dimensions()
                 print(f"Unknown board with size {size.width} x {size.height}")
 
-            assert trans.is_connected()
+            assert any(c.is_connected() for c in trans._scamp_connections)
             print(trans._get_scamp_version())
             print(trans.get_cpu_infos())
 
     def test_boot_board(self):
-        board_config.set_up_remote_board()
+        self.board_config.set_up_remote_board()
         with transceiver.create_transceiver_from_hostname(
-                board_config.remotehost, board_config.board_version) as trans:
-            # self.assertFalse(trans.is_connected())
+                self.board_config.remotehost,
+                self.board_config.board_version) as trans:
+            # self.assertFalse(trans.is_connected(        unittest_setup()))
             trans._boot_board()
 
     def test_set_watch_dog(self):


### PR DESCRIPTION
The test board spinn-4.cs.man.ac.uk was down which allowed some bugs to creep in.
This because the test where skipped

Before approving this PR please restart spinn-4.cs.man.ac.uk and rerun the tests

1. BoardTestConfiguration changed from using a cfg file to a trial and error method
- Will try a 4 Chip board first than spinn-4.cs.man.ac.uk and then 192.168.240.1
- (minus) This will make the unit test take longer 45s instead of 19s if all three options are not pingable
- (plus) Automatically uses three different options so more likely to run the tests rather than skipping
- Can still be changed locally but by editing board_test_configuration.py rather than board_test_configuration.cfg

2. BoardTestConfiguration now set cfg Machine/version so unittest_setup() needs to be called first

3. Transceiver unittest use some private properties as they are testing/ using things not required by the normal runs.
Alternatives are:
1. Add api methods just for testing
2. Remove the Tests


Depends on:
https://github.com/SpiNNakerManchester/SpiNNMachine/pull/218
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1098
tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/223