### PR TITLE
Power on during init

### DIFF
--- a/quick_tests/quick_tests.py
+++ b/quick_tests/quick_tests.py
@@ -155,7 +155,7 @@ class Section(object):
 def print_transceiver_tests(transceiver):
 
     with Section("Version Information"):
-        version_info = transceiver.ensure_board_is_ready()
+        version_info = transceiver._ensure_board_is_ready()
         print(version_info)
 
     app_id = SpiNNManDataView().get_new_id()

--- a/quick_tests/quick_tests.py
+++ b/quick_tests/quick_tests.py
@@ -155,7 +155,7 @@ class Section(object):
 def print_transceiver_tests(transceiver):
 
     with Section("Version Information"):
-        version_info = transceiver._ensure_board_is_ready()
+        version_info = transceiver._get_scamp_version()
         print(version_info)
 
     app_id = SpiNNManDataView().get_new_id()

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -169,7 +169,8 @@ def create_transceiver_from_hostname(
     # handle the boot connection
     connections.append(BootConnection(remote_host=hostname))
 
-    return Transceiver(version, connections=connections)
+    return Transceiver(version, connections=connections,
+                       power_cycle=power_cycle)
 
 
 class Transceiver(AbstractContextManager):
@@ -1940,7 +1941,7 @@ class Transceiver(AbstractContextManager):
         """
         if self._bmp_connection is not None:
             if get_config_bool("Machine", "turn_off_machine"):
-                self.power_off_machine()
+                self._power_off_machine()
 
         for connection in self._all_connections:
             connection.close()

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -679,7 +679,6 @@ class Transceiver(AbstractContextManager):
             This should only be used for values which are not standard
             based on the board version.
         :return: The version identifier
-        :rtype: VersionInfo
         :raise SpinnmanIOException:
             * If there is a problem booting the board
             * If the version of software on the board is not compatible with
@@ -741,8 +740,6 @@ class Transceiver(AbstractContextManager):
         # Update the connection selector so that it can ask for processor ids
         self._scamp_connection_selector = MostDirectConnectionSelector(
             self._scamp_connections)
-
-        return version_info
 
     def __is_default_destination(self, version_info):
         return (version_info.x == AbstractSCPRequest.DEFAULT_DEST_X_COORD

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -34,7 +34,7 @@ from spinnman.constants import (
     UDP_BOOT_CONNECTION_DEFAULT_PORT, NO_ROUTER_DIAGNOSTIC_FILTERS,
     ROUTER_REGISTER_BASE_ADDRESS, ROUTER_DEFAULT_FILTERS_MAX_POSITION,
     ROUTER_FILTER_CONTROLS_OFFSET, ROUTER_DIAGNOSTIC_FILTER_SIZE, N_RETRIES,
-    BOOT_RETRIES)
+    BOOT_RETRIES, POWER_CYCLE_WAIT_TIME_IN_SECONDS)
 from spinnman.data import SpiNNManDataView
 from spinnman.exceptions import (
     SpinnmanInvalidParameterException, SpinnmanException, SpinnmanIOException,
@@ -88,10 +88,27 @@ _ONE_WORD = struct.Struct("<I")
 _ONE_LONG = struct.Struct("<Q")
 _EXECUTABLE_ADDRESS = 0x67800000
 
+_POWER_CYCLE_WARNING = (
+    "When power-cycling a board, it is recommended that you wait for 30 "
+    "seconds before attempting a reboot. Therefore, the tools will now "
+    "wait for 30 seconds. If you wish to avoid this wait, please set "
+    "reset_machine_on_startup = False in the [Machine] section of the "
+    "relevant configuration (cfg) file.")
+
+_POWER_CYCLE_FAILURE_WARNING = (
+    "The end user requested the power-cycling of the board. But the "
+    "tools did not have the required BMP connection to facilitate a "
+    "power-cycling, and therefore will not do so. please set the "
+    "bmp_names accordingly in the [Machine] section of the relevant "
+    "configuration (cfg) file. Or use a machine assess process which "
+    "provides the BMP data (such as a spalloc system) or finally set "
+    "reset_machine_on_startup = False in the [Machine] section of the "
+    "relevant configuration (cfg) file to avoid this warning in future.")
+
 
 def create_transceiver_from_hostname(
         hostname, version, bmp_connection_data=None, number_of_boards=None,
-        auto_detect_bmp=False):
+        auto_detect_bmp=False, power_cycle=False):
     """
     Create a Transceiver by creating a :py:class:`~.UDPConnection` to the
     given hostname on port 17893 (the default SCAMP port), and a
@@ -116,6 +133,7 @@ def create_transceiver_from_hostname(
         automatically determined from the board IP address
     :param scamp_connections:
         the list of connections used for SCAMP communications
+    :param bool power_cycle: If True will power cycle the machine:
     :return: The created transceiver
     :rtype: Transceiver
     :raise SpinnmanIOException:
@@ -188,12 +206,13 @@ class Transceiver(AbstractContextManager):
         "_width"]
 
     def __init__(
-            self, version, connections=None):
+            self, version, connections=None, power_cycle=False):
         """
         :param int version: The version of the board being connected to
         :param list(Connection) connections:
             An iterable of connections to the board.  If not specified, no
             communication will be possible until connections are found.
+        :param bool power_cycle: If True will power cycle the machine:
         :raise SpinnmanIOException:
             If there is an error communicating with the board, or if no
             connections to the board can be found (if connections is ``None``)
@@ -252,6 +271,10 @@ class Transceiver(AbstractContextManager):
         self.__check_bmp_connection()
 
         self._machine_off = False
+
+        if power_cycle:
+            self._power_off_machine()
+        self._ensure_board_is_ready()
 
     def _where_is_xy(self, x, y):
         """
@@ -641,7 +664,7 @@ class Transceiver(AbstractContextManager):
         # version is irrelevant
         return version[1] > _SCAMP_VERSION[1]
 
-    def ensure_board_is_ready(self, n_retries=5, extra_boot_values=None):
+    def _ensure_board_is_ready(self, n_retries=5, extra_boot_values=None):
         """
         Ensure that the board is ready to interact with this version of the
         transceiver. Boots the board if not already booted and verifies that
@@ -1050,65 +1073,43 @@ class Transceiver(AbstractContextManager):
         """
         Power on the whole machine.
 
-        :rtype bool
         :return success of failure to power on machine
         """
         if self._bmp_connection is None:
             logger.warning("No BMP connections, so can't power on")
-            return False
-        self.power_on(self._bmp_connection)
-        return True
+        self._power(PowerCommand.POWER_ON)
+        self._machine_off = True
+        # Sleep for 5 seconds as the machine has just been powered on
+        time.sleep(BMP_POST_POWER_ON_SLEEP_TIME)
 
-    def power_on(self, boards=0):
-        """
-        Power on a set of boards in the machine.
-
-        :param int boards: The board or boards to power on
-        """
-        self._power(PowerCommand.POWER_ON, boards)
-
-    def power_off_machine(self):
+    def _power_off_machine(self):
         """
         Power off the whole machine.
 
-        :rtype bool
         :return success or failure to power off the machine
         """
         if self._bmp_connection is None:
-            logger.warning("No BMP connections, so can't power off")
-            return False
-        logger.info("Turning off machine")
-        self.power_off(self._bmp_connection)
-        return True
+            logger.warning(_POWER_CYCLE_FAILURE_WARNING)
+        self._power(PowerCommand.POWER_OFF)
+        logger.warning(_POWER_CYCLE_WARNING)
+        time.sleep(POWER_CYCLE_WAIT_TIME_IN_SECONDS)
+        logger.warning("Power cycle wait complete")
 
-    def power_off(self, boards=0):
-        """
-        Power off a set of boards in the machine.
-
-        :param int boards: The board or boards to power off
-        """
-        self._power(PowerCommand.POWER_OFF, boards)
-
-    def _power(self, power_command, boards=0):
+    def _power(self, power_command):
         """
         Send a power request to the machine.
 
         :param PowerCommand power_command: The power command to send
         :param boards: The board or boards to send the command to
         """
-        connection_selector = self._bmp_selector
         timeout = (
             BMP_POWER_ON_TIMEOUT
             if power_command == PowerCommand.POWER_ON
             else BMP_TIMEOUT)
         process = SendSingleCommandProcess(
-            connection_selector, timeout=timeout, n_retries=0)
-        process.execute(SetPower(power_command, boards))
+            self._bmp_selector, timeout=timeout, n_retries=0)
+        process.execute(SetPower(power_command, self._bmp_connection.boards))
         self._machine_off = power_command == PowerCommand.POWER_OFF
-
-        # Sleep for 5 seconds if the machine has just been powered on
-        if not self._machine_off:
-            time.sleep(BMP_POST_POWER_ON_SLEEP_TIME)
 
     def read_fpga_register(
             self, fpga_num, register, board=0):

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -58,6 +58,9 @@ class MockWriteTransceiver(Transceiver):
     def close(self):
         pass
 
+    def _ensure_board_is_ready(self, n_retries=5, extra_boot_values=None):
+        pass
+
 
 class MockExtendedTransceiver(MockWriteTransceiver, ExtendedTransceiver):
     pass


### PR DESCRIPTION
move the code to make sure the board is on into the transceiver.

This includes power off the board is requested and possible

.ensure_board_is_ready

must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1101

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/227



