### PR TITLE
protected Cpu info methods

### DIFF
--- a/quick_tests/quick_tests.py
+++ b/quick_tests/quick_tests.py
@@ -191,7 +191,7 @@ def print_transceiver_tests(transceiver):
             time.sleep(0.1)
 
     with Section("CPU Information"):
-        cpu_infos = transceiver.get_cpu_infos(core_subsets)
+        cpu_infos = transceiver._get_cpu_infos(core_subsets)
         cpu_infos = sorted(cpu_infos, key=lambda x: (x.x, x.y, x.p))
         print("{} CPUs".format(len(cpu_infos)))
         for cpu_info in cpu_infos:
@@ -213,7 +213,7 @@ def print_transceiver_tests(transceiver):
     with Section("Stop Application"):
         transceiver.send_signal(app_id, Signal.STOP)
         time.sleep(0.5)
-        cpu_infos = transceiver.get_cpu_infos(core_subsets)
+        cpu_infos = transceiver._get_cpu_infos(core_subsets)
         cpu_infos = sorted(cpu_infos, key=lambda x: (x.x, x.y, x.p))
         print("{} CPUs".format(len(cpu_infos)))
         for cpu_info in cpu_infos:

--- a/spinnman/extended/extended_transceiver.py
+++ b/spinnman/extended/extended_transceiver.py
@@ -415,7 +415,7 @@ class ExtendedTransceiver(Transceiver):
         # Check that the binaries have reached a wait state
         count = self.get_core_state_count(app_id, CPUState.READY)
         if count < executable_targets.total_processors:
-            cores_ready = self.get_cpu_infos(
+            cores_ready = self._get_cpu_infos(
                 executable_targets.all_core_subsets, [CPUState.READY],
                 include=False)
             if len(cores_ready) > 0:

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -46,6 +46,8 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
     for chip in machine.chips:
         all_cores.append(CoreSubset(chip.x, chip.y, range(1, 17)))
 
+    all_cores = CoreSubsets(core_subsets=all_cores)
+
     cores_running = txrx.get_cores_in_states(all_cores, CPUState.RUNNING)
     for (x, y, p), _ in cores_running:
         if p not in IGNORED_IDS:

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -48,9 +48,9 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
 
     all_cores = CoreSubsets(core_subsets=all_cores)
 
-    cpu_infos = txrx.get_cpu_infos(
-        all_cores,
-        [CPUState.FINISHED, CPUState.RUNNING, CPUState.WATCHDOG], True)
+    cpu_infos = txrx._get_cpu_infos(all_cores,
+                                    [CPUState.FINISHED, CPUState.RUNNING,
+                                     CPUState.WATCHDOG], True)
     cores_finished = cpu_infos.infos_for_state(CPUState.FINISHED)
     cores_running = cpu_infos.infos_for_state(CPUState.RUNNING)
     cores_watchdog = cpu_infos.infos_for_state(CPUState.WATCHDOG)

--- a/spinnman/get_cores_in_run_state.py
+++ b/spinnman/get_cores_in_run_state.py
@@ -46,22 +46,16 @@ def get_cores_in_run_state(txrx, app_id, print_all_chips):
     for chip in machine.chips:
         all_cores.append(CoreSubset(chip.x, chip.y, range(1, 17)))
 
-    all_cores = CoreSubsets(core_subsets=all_cores)
-
-    cpu_infos = txrx._get_cpu_infos(all_cores,
-                                    [CPUState.FINISHED, CPUState.RUNNING,
-                                     CPUState.WATCHDOG], True)
-    cores_finished = cpu_infos.infos_for_state(CPUState.FINISHED)
-    cores_running = cpu_infos.infos_for_state(CPUState.RUNNING)
-    cores_watchdog = cpu_infos.infos_for_state(CPUState.WATCHDOG)
-
+    cores_running = txrx.get_cores_in_states(all_cores, CPUState.RUNNING)
     for (x, y, p), _ in cores_running:
         if p not in IGNORED_IDS:
             print(f'run core: {x} {y} {p}')
 
+    cores_finished = txrx.get_cores_in_states(all_cores, CPUState.FINISHED)
     for (x, y, p), _ in cores_finished:
         print(f'finished core: {x} {y} {p}')
 
+    cores_watchdog = txrx.get_cores_in_states(all_cores, CPUState.WATCHDOG)
     for (x, y, p), _ in cores_watchdog:
         print(f'watchdog core: {x} {y} {p}')
 

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -329,3 +329,24 @@ class CPUInfo(object):
         return "{}:{}:{:02n} ({:02n}) {:18} {:16s} {:3n}".format(
             self.x, self.y, self.p, self.physical_cpu_id, self._state.name,
             self._application_name, self._application_id)
+
+    def get_status_string(self):
+        """
+        Get a string indicating the status of the given core.
+
+        :rtype: str
+        """
+        if self.state == CPUState.RUN_TIME_EXCEPTION:
+            return (
+                f"{self._x}:{self._y}:{self._p} " 
+                f"(ph: {self._physical_cpu_id}) "
+                f"in state {self._state.name}:{self._run_time_error.name}\n"
+                f"    r0={self._registers[0]}, r1={self._registers[1]}, "
+                f"r2={self._registers[2]}, r3={self._registers[3]}\n"
+                f"    r4={self._registers[4]}, r5={self._registers[5]}, "
+                f"r6={self._registers[6]}, r7={self._registers[7]}\n"
+                f"    PSR={self._processor_state_register}, "
+                f"SP={self._stack_pointer}, LR={self._link_register}\n")
+        else:
+            return (
+                f"{self._x}:{self._y}:{self._p} in state {self._state.name}\n")

--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -128,24 +128,9 @@ class CPUInfos(object):
         :param CPUInfos cpu_infos: A CPUInfos objects
         :rtype: str
         """
-        break_down = "\n"
-        for (x, y, p), core_info in self.cpu_infos:
-            if core_info.state == CPUState.RUN_TIME_EXCEPTION:
-                break_down += "    {}:{}:{} (ph: {}) in state {}:{}\n".format(
-                    x, y, p, core_info.physical_cpu_id, core_info.state.name,
-                    core_info.run_time_error.name)
-                break_down += "        r0={}, r1={}, r2={}, r3={}\n".format(
-                    core_info.registers[0], core_info.registers[1],
-                    core_info.registers[2], core_info.registers[3])
-                break_down += "        r4={}, r5={}, r6={}, r7={}\n".format(
-                    core_info.registers[4], core_info.registers[5],
-                    core_info.registers[6], core_info.registers[7])
-                break_down += "        PSR={}, SP={}, LR={}\n".format(
-                    core_info.processor_state_register,
-                    core_info.stack_pointer, core_info.link_register)
-            else:
-                break_down += "    {}:{}:{} in state {}\n".format(
-                    x, y, p, core_info.state.name)
+        break_down = ""
+        for core_info in self._cpu_infos.values():
+            break_down += core_info.get_status_string()
         return break_down
 
     def __str__(self):

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -1000,11 +1000,14 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
+        a = self.read_user(x, y, p, 0)
         core_subsets = CoreSubsets()
         core_subsets.add_processor(x, y, p)
         process = GetCPUInfoProcess(self._scamp_connection_selector)
         cpu_info = process.get_cpu_info(core_subsets)
-        return cpu_info.get_cpu_info(x, y, p).user[0]
+        b = cpu_info.get_cpu_info(x, y, p).user[0]
+        assert a == b
+        return a
 
     def get_iobuf(self, core_subsets=None):
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -843,7 +843,16 @@ class Transceiver(AbstractContextManager):
         :param states: The state or states to filter on (if any)
         :type states: None, CPUState or iterable(CPUState)
         :return: An iterable which yields x, y, p for each core in this state
-        rtype: iterable(int, int, int)
+        :rtype: iterable(int, int, int)
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If chip_and_cores contains invalid items
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
         """
         return self._get_cpu_infos(core_subsets, states, True)
 
@@ -856,14 +865,23 @@ class Transceiver(AbstractContextManager):
             requirement from callers and therefor only contract is that the
             result type can be used like: for (x, y, p) in
 
-       :param ~spinn_machine.CoreSubsets core_subsets:
+        :param ~spinn_machine.CoreSubsets core_subsets:
             A set of chips and cores from which to get the
             information. If not specified, the information from all of the
             cores on all of the chips on the board are obtained.
         :param states: The state or states to filter on (if any)
         :type states: None, CPUState or iterable(CPUState)
         :return: An iterable which yields x, y, p for each core in this state
-        rtype: iterable(int, int, int)
+        :rtype: iterable(int, int, int)
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If chip_and_cores contains invalid items
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
         """
         return self._get_cpu_infos(core_subsets, states, False)
 

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -923,6 +923,30 @@ class Transceiver(AbstractContextManager):
         cpu_infos = self.get_cpu_infos(core_subsets)
         return cpu_infos.get_cpu_info(x, y, p)
 
+    def get_region_base_address(self, x, y, p):
+        """
+        Gets the base address of the Region Table
+
+        :param int x: The x-coordinate of the chip containing the processor
+        :param int y: The y-coordinate of the chip containing the processor
+        :param int p: The ID of the processor to get the address
+        :return: The adddress of the Region table for the selected core
+        :rtype: int
+        :raise SpinnmanIOException:
+            If there is an error communicating with the board
+        :raise SpinnmanInvalidPacketException:
+            If a packet is received that is not in the valid format
+        :raise SpinnmanInvalidParameterException:
+            * If x, y, p is not a valid processor
+            * If a packet is received that has invalid parameters
+        :raise SpinnmanUnexpectedResponseCodeException:
+            If a response indicates an error during the exchange
+        """
+        core_subsets = CoreSubsets()
+        core_subsets.add_processor(x, y, p)
+        cpu_infos = self.get_cpu_infos(core_subsets)
+        return cpu_infos.get_cpu_info(x, y, p).user[0]
+
     def get_iobuf(self, core_subsets=None):
         """
         Get the contents of the IOBUF buffer for a number of processors.

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -998,14 +998,7 @@ class Transceiver(AbstractContextManager):
         :raise SpinnmanUnexpectedResponseCodeException:
             If a response indicates an error during the exchange
         """
-        a = self.read_user(x, y, p, 0)
-        core_subsets = CoreSubsets()
-        core_subsets.add_processor(x, y, p)
-        process = GetCPUInfoProcess(self._scamp_connection_selector)
-        cpu_info = process.get_cpu_info(core_subsets)
-        b = cpu_info.get_cpu_info(x, y, p).user[0]
-        assert a == b
-        return a
+        return self.read_user(x, y, p, 0)
 
     def get_iobuf(self, core_subsets=None):
         """

--- a/spinnman/transceiver.py
+++ b/spinnman/transceiver.py
@@ -836,7 +836,7 @@ class Transceiver(AbstractContextManager):
             requirement from callers and therefor only contract is that the
             result type can be used like: for (x, y, p) in
 
-       :param ~spinn_machine.CoreSubsets core_subsets:
+        :param ~spinn_machine.CoreSubsets core_subsets:
             A set of chips and cores from which to get the
             information. If not specified, the information from all of the
             cores on all of the chips on the board are obtained.

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -43,9 +43,12 @@ class TestCpuInfos(unittest.TestCase):
         infos.add_info(info)
         info = CPUInfo(1, 0, 1, self.make_info_data(7, CPUState.FINISHED))
         infos.add_info(info)
+        info = CPUInfo(1, 1, 2, self.make_info_data(4, CPUState.RUN_TIME_EXCEPTION))
+        infos.add_info(info)
 
+        self.assertSetEqual(set(infos), {(1, 0, 1), (0, 0, 1), (0, 0, 2), (1, 1, 2)})
         self.assertEqual(
-            "['0, 0, 1 (ph: 5)', '0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)']",
+            "['0, 0, 1 (ph: 5)', '0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)', '1, 1, 2 (ph: 4)']",
             str(infos))
 
         finished = infos.infos_for_state(CPUState.FINISHED)
@@ -60,9 +63,14 @@ class TestCpuInfos(unittest.TestCase):
         self.assertEqual(
             "0:0:02 (06) FINISHED           scamp-3            0", str(info))
 
-        a = set(infos)
-        b = str(a)
-        print(b)
+        self.assertEqual(infos.get_status_string(),
+                         "0:0:1 in state RUNNING\n"
+                         "0:0:2 in state FINISHED\n"
+                         "1:0:1 in state FINISHED\n"
+                         "1:1:2 (ph: 4) in state RUN_TIME_EXCEPTION:NONE\n"
+                         "    r0=134676544, r1=255, r2=8388608, r3=173\n"
+                         "    r4=0, r5=0, r6=0, r7=0\n"
+                         "    PSR=0, SP=0, LR=0\n")
 
 
 if __name__ == '__main__':

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -60,6 +60,10 @@ class TestCpuInfos(unittest.TestCase):
         self.assertEqual(
             "0:0:02 (06) FINISHED           scamp-3            0", str(info))
 
+        a = set(infos)
+        b = str(a)
+        print(b)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -119,7 +119,7 @@ class TestTransceiver(unittest.TestCase):
 
             assert any(c.is_connected() for c in trans._scamp_connections)
             print(trans._get_scamp_version())
-            print(trans.get_cpu_infos())
+            print(trans._get_cpu_infos())
 
     def test_boot_board(self):
         self.board_config.set_up_remote_board()


### PR DESCRIPTION
This PR looks at the Transceiver functions
get_cpu_information_from_cores and get_cpu_infos
to see why these are called.

Turns out the usages where
1. get_region_base_address
2. get_cores_in_states
3. get_cores_in_not_states
4. Print a String of the cores in/ not in states

So instead the methods that return detail CPUInfo objects have need protected and instead methods 1 to 3 have been added.

Methods 2 and 3 currently still return CPuInfo objects BUT only their iter method of this Object is used
This allows the Spin2 to do it differently if desired

Method 4 can actually be replicated by calling methods 2 or 3 using the x,y,p iter to a fill a set (or list) and then str that

There is a minor disadvantage that is rare cases 
ChipProvenanceUpdater if it is going to call an Exception then it needs to make a few extra calls 
Stand alone script get_cores_in_run_state also needs a few extra calls

Must be done at the same time as: 
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1104
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1379
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/257

tested by:https://github.com/SpiNNakerManchester/IntegrationTests/pull/230


