### PR TITLE
Use less transactions

### DIFF
--- a/spinnman/spalloc/spalloc_client.py
+++ b/spinnman/spalloc/spalloc_client.py
@@ -457,8 +457,8 @@ class _SpallocJob(SessionAware, SpallocJob):
         self.__proxy_thread = None
         self.__proxy_ping = None
 
-    @overrides(SpallocJob._write_session_credentials_to_db)
-    def _write_session_credentials_to_db(self, cur):
+    @overrides(SpallocJob.get_session_credentials_for_db)
+    def get_session_credentials_for_db(self):
         config = {}
         config["SPALLOC", "service uri"] = self._service_url
         config["SPALLOC", "job uri"] = self._url
@@ -471,10 +471,7 @@ class _SpallocJob(SessionAware, SpallocJob):
             # We never write the auth headers themselves; we just extend the
             # session
             del headers["Authorization"]
-        cur.executemany("""
-            INSERT INTO proxy_configuration(kind, name, value)
-            VALUES(?, ?, ?)
-            """, [(k1, k2, v) for (k1, k2), v in config.items()])
+        return config
 
     @overrides(SpallocJob.get_state)
     def get_state(self):

--- a/spinnman/spalloc/spalloc_client.py
+++ b/spinnman/spalloc/spalloc_client.py
@@ -21,7 +21,6 @@ from time import sleep
 from packaging.version import Version
 import queue
 import requests
-import sqlite3
 import struct
 import threading
 from typing import Dict, List, Tuple
@@ -98,7 +97,8 @@ class SpallocClient(AbstractContextManager, AbstractSpallocClient):
         logger.info("established session to {} for {}", service_url, username)
 
     @staticmethod
-    def open_job_from_database(service_url, job_url, cookies, headers) -> SpallocJob:
+    def open_job_from_database(
+            service_url, job_url, cookies, headers) -> SpallocJob:
         """
         Create a job from the description in the attached database. This is
         intended to allow for access to the job's allocated resources from

--- a/spinnman/spalloc/spalloc_job.py
+++ b/spinnman/spalloc/spalloc_job.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sqlite3 import Cursor
 from typing import Dict, Tuple
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_utilities.abstract_context_manager import AbstractContextManager

--- a/spinnman/spalloc/spalloc_job.py
+++ b/spinnman/spalloc/spalloc_job.py
@@ -194,17 +194,13 @@ class SpallocJob(object, metaclass=AbstractBase):
         """
 
     @abstractmethod
-    def _write_session_credentials_to_db(self, cur: Cursor):
+    def get_session_credentials_for_db(self):
         """
-        Write the session credentials for the job to the database accessed by
-        the given cursor.
+        Get the session credentials for the job to be written into a database
 
         .. note::
             May assume that there is a ``proxy_configuration`` table with
             ``kind``, ``name`` and ``value`` columns.
-
-        :param ~sqlite3.Cursor cur:
-            The open cursor to the database.
         """
 
     def __enter__(self):


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1112

Database queries have been moved into FEC

open_job_from_database now gets the data read from the database rather than a connection

_write_session_credentials_to_db replaced with get_session_credentials_for_db which just returns the data for the caller to add to the database

