### PR TITLE
send_chip_update_provenance_and_exit to abstract

### DIFF
--- a/spinnman/transceiver/base_transceiver.py
+++ b/spinnman/transceiver/base_transceiver.py
@@ -1241,22 +1241,8 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
         process.execute(WriteMemory(
             x, y, memory_position, _ONE_WORD.pack(data_to_send)))
 
+    @overrides(Transceiver.clear_router_diagnostic_counters)
     def clear_router_diagnostic_counters(self, x, y):
-        """
-        Clear router diagnostic information on a chip.
-
-        :param int x: The x-coordinate of the chip
-        :param int y: The y-coordinate of the chip
-        :raise SpinnmanIOException:
-            If there is an error communicating with the board
-        :raise SpinnmanInvalidPacketException:
-            If a packet is received that is not in the valid format
-        :raise SpinnmanInvalidParameterException:
-            If a packet is received that has invalid parameters or a counter
-            ID is out of range
-        :raise SpinnmanUnexpectedResponseCodeException:
-            If a response indicates an error during the exchange
-        """
         try:
             process = SendSingleCommandProcess(self._scamp_connection_selector)
             # Clear all
@@ -1266,10 +1252,8 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
             logger.info(self.where_is_xy(x, y))
             raise
 
+    @overrides(Transceiver.close)
     def close(self):
-        """
-        Close the transceiver and any threads that are running.
-        """
         if self._bmp_connection is not None:
             if get_config_bool("Machine", "turn_off_machine"):
                 self._power_off_machine()
@@ -1277,26 +1261,13 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
         for connection in self._all_connections:
             connection.close()
 
+    @overrides(Transceiver.control_sync)
     def control_sync(self, do_sync):
-        """
-        Control the synchronisation of the chips.
-
-        :param bool do_sync: Whether to synchronise or not
-        """
         process = SendSingleCommandProcess(self._scamp_connection_selector)
         process.execute(DoSync(do_sync))
 
+    @overrides(Transceiver.update_provenance_and_exit)
     def update_provenance_and_exit(self, x, y, p):
-        """
-        Sends a command to update prevenance and exit
-
-        :param int x:
-            The x-coordinate of the core
-        :param int y:
-            The y-coordinate of the core
-        :param int p:
-            The processor on the core
-        """
         # Send these signals to make sure the application isn't stuck
         self.send_sdp_message(SDPMessage(
             sdp_header=SDPHeader(
@@ -1306,14 +1277,8 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
             data=_ONE_WORD.pack(SDP_RUNNING_MESSAGE_CODES
                                 .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)))
 
+    @overrides(Transceiver.send_chip_update_provenance_and_exit)
     def send_chip_update_provenance_and_exit(self, x, y, p):
-        """
-        Sends a singnal to update the provenance and exit
-
-        :param int x:
-        :param int y:
-        :param int p:
-        """
         cmd = SDP_RUNNING_MESSAGE_CODES.SDP_UPDATE_PROVENCE_REGION_AND_EXIT
         port = SDP_PORTS.RUNNING_COMMAND_SDP_PORT
 

--- a/spinnman/transceiver/mockable_transceiver.py
+++ b/spinnman/transceiver/mockable_transceiver.py
@@ -97,12 +97,6 @@ class MockableTransceiver(ExtendableTransceiver):
 
     @overrides(Transceiver.read_bmp_version)
     def read_bmp_version(self, board):
-        """
-        Read the BMP version.
-
-        :param int board: which board to request the data from
-        :return: the sver from the BMP
-        """
         raise NotImplementedError("Needs to be mocked")
 
     @overrides(Transceiver.write_memory)
@@ -203,6 +197,10 @@ class MockableTransceiver(ExtendableTransceiver):
 
     @overrides(Transceiver.update_provenance_and_exit)
     def update_provenance_and_exit(self, x, y, p):
+        pass
+
+    @overrides(Transceiver.send_chip_update_provenance_and_exit)
+    def send_chip_update_provenance_and_exit(self, x, y, p):
         pass
 
     @overrides(Transceiver.where_is_xy)

--- a/spinnman/transceiver/transceiver.py
+++ b/spinnman/transceiver/transceiver.py
@@ -233,7 +233,7 @@ class Transceiver(object):
         :param int x: The x-coordinate of the chip containing the processor
         :param int y: The y-coordinate of the chip containing the processor
         :param int p: The ID of the processor to get the address
-        :return: The adddress of the Region table for the selected core
+        :return: The address of the Region table for the selected core
         :rtype: int
         :raise SpinnmanIOException:
             If there is an error communicating with the board
@@ -380,7 +380,7 @@ class Transceiver(object):
         Read the BMP version.
 
         :param int board: which board to request the data from
-        :return: the sver from the BMP
+        :return: the version_info from the BMP
         """
 
     @abstractmethod
@@ -883,7 +883,7 @@ class Transceiver(object):
     @abstractmethod
     def update_provenance_and_exit(self, x, y, p):
         """
-        Sends a command to update prevenance and exit
+        Sends a command to update provenance and exit
 
         :param int x:
             The x-coordinate of the core
@@ -891,6 +891,16 @@ class Transceiver(object):
             The y-coordinate of the core
         :param int p:
             The processor on the core
+        """
+
+    @abstractmethod
+    def send_chip_update_provenance_and_exit(self, x, y, p):
+        """
+        Sends a signal to update the provenance and exit
+
+        :param int x:
+        :param int y:
+        :param int p:
         """
 
     @abstractmethod


### PR DESCRIPTION
In the various merges method send_chip_update_provenance_and_exit was not added to the (Abstract)Tranceiver

Various other methods where not marked with overrides 

docs moved to Abstract class only.

Spellings in docs fixed.