### PR TITLE
Minor param renaming, doc fixes and ignores for spelling checker

### DIFF
--- a/.pylint_dict.txt
+++ b/.pylint_dict.txt
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 # Our abbreviations/names
+bmp
+cpu
+iobuf
+scp
 Spalloc
 bmpc
 ybug
 txrx
+xys
 
 # Our special words
 keepalive
@@ -29,7 +34,15 @@ BMPConnectionData
 BufferedIOBase
 CoreSubset
 CPUInfo
+CPUInfos
 CPUState
+DiagnosticFilter
+DiagnosticFilterDestination
+DiagnosticFilterDefaultRoutingStatus
+DiagnosticFilterEmergencyRoutingStatus
+DiagnosticFilterPacketType
+DiagnosticFilterSource
+ExecutableType
 HeapElement
 IOBuffer
 RawIOBase

--- a/.pylint_dict.txt
+++ b/.pylint_dict.txt
@@ -21,12 +21,15 @@ Spalloc
 bmpc
 ybug
 txrx
+url
+xy
 xys
 
 # Our special words
 keepalive
 
 # Python packages
+spinnman
 websocket
 
 # Python types
@@ -45,8 +48,10 @@ DiagnosticFilterSource
 ExecutableType
 HeapElement
 IOBuffer
+PreparedRequest
 RawIOBase
 SCAMPConnection
+SpallocMachine
 SpinnakerBootMessage
 SystemVariableDefinition
 WebSocket

--- a/.pylint_dict.txt
+++ b/.pylint_dict.txt
@@ -27,6 +27,9 @@ xys
 
 # Our special words
 keepalive
+# Our special words ("wrap-arounds" gets split up)
+arounds
+
 
 # Python packages
 spinnman
@@ -44,6 +47,7 @@ DiagnosticFilterDestination
 DiagnosticFilterDefaultRoutingStatus
 DiagnosticFilterEmergencyRoutingStatus
 DiagnosticFilterPacketType
+DiagnosticFilterPayloadStatus
 DiagnosticFilterSource
 ExecutableType
 HeapElement
@@ -51,6 +55,8 @@ IOBuffer
 PreparedRequest
 RawIOBase
 SCAMPConnection
+SCPResult
+SpallocJob
 SpallocMachine
 SpinnakerBootMessage
 SystemVariableDefinition

--- a/spinnman/messages/scp/impl/app_copy_run.py
+++ b/spinnman/messages/scp/impl/app_copy_run.py
@@ -30,7 +30,7 @@ class AppCopyRun(AbstractSCPRequest):
     """
     __slots__ = ["__link"]
 
-    def __init__(self, x, y, link, size, app_id, processors, chksum,
+    def __init__(self, x, y, link, size, app_id, processors, checksum,
                  wait=False):
         """
         :param int x:
@@ -41,7 +41,7 @@ class AppCopyRun(AbstractSCPRequest):
         :param int size: The number of bytes to read, must be divisible by 4
         :param int app_id: The app to associate the copied binary with
         :param list(int) processors: The processors to start on the chip
-        :param int chksum: The checksum of the data to copy
+        :param int checksum: The checksum of the data to copy
         :param bool wait: Whether to start in wait mode or not
         """
         # pylint: disable=too-many-arguments
@@ -59,7 +59,7 @@ class AppCopyRun(AbstractSCPRequest):
             processor_mask |= _WAIT_FLAG
         self.__link = link
 
-        arg1 = ((chksum & 0x1FFFFFFF) << 3) | link
+        arg1 = ((checksum & 0x1FFFFFFF) << 3) | link
 
         super().__init__(
             SDPHeader(

--- a/spinnman/messages/scp/impl/iptag_get.py
+++ b/spinnman/messages/scp/impl/iptag_get.py
@@ -169,8 +169,8 @@ class _SCPIPTagGetResponse(AbstractSCPResponse):
     @property
     def is_arp(self):
         """
-        Whether the tag is in the ARP state (where the MAC address is
-        being looked up).
+        Whether the tag is in the Address Resolution Protocol state
+        (where the MAC address is being looked up).
 
         .. note::
             This is a transient state; it is unlikely to be observed.

--- a/spinnman/messages/scp/impl/write_fpga_register.py
+++ b/spinnman/messages/scp/impl/write_fpga_register.py
@@ -40,8 +40,8 @@ class WriteFPGARegister(BMPRequest):
     def __init__(self, fpga_num, address, value, board):
         """
         :param int fpga_num: FPGA number (0, 1 or 2) to communicate with.
-        :param int address: Register address to read or write to (will be rounded
-            down to the nearest 32-bit word boundary).
+        :param int address: Register address to read or write to
+            (will be rounded down to the nearest 32-bit word boundary).
         :param int value: A 32-bit int value to write to the register
         """
         super().__init__(

--- a/spinnman/messages/scp/impl/write_fpga_register.py
+++ b/spinnman/messages/scp/impl/write_fpga_register.py
@@ -23,6 +23,7 @@ from .check_ok_response import CheckOKResponse
 _ONE_WORD = struct.Struct("<I")
 
 
+# pylint: disable=wrong-spelling-in-docstring
 class WriteFPGARegister(BMPRequest):
     """
     A request for writing a word to a FPGA (SPI) register.
@@ -36,17 +37,17 @@ class WriteFPGARegister(BMPRequest):
     """
     __slots__ = []
 
-    def __init__(self, fpga_num, addr, value, board):
+    def __init__(self, fpga_num, address, value, board):
         """
         :param int fpga_num: FPGA number (0, 1 or 2) to communicate with.
-        :param int addr: Register address to read or write to (will be rounded
+        :param int address: Register address to read or write to (will be rounded
             down to the nearest 32-bit word boundary).
         :param int value: A 32-bit int value to write to the register
         """
         super().__init__(
             board,
             SCPRequestHeader(command=SCPCommand.CMD_LINK_WRITE),
-            argument_1=addr & (~0x3), argument_2=4, argument_3=fpga_num,
+            argument_1=address & (~0x3), argument_2=4, argument_3=fpga_num,
             data=_ONE_WORD.pack(value))
 
     @overrides(AbstractSCPRequest.get_scp_response)

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -270,7 +270,7 @@ class CPUInfo(object):
         """
         The current stack pointer value.
 
-        :return: The stack pointervalue
+        :return: The stack pointer value
         :rtype: int
         """
         return self._stack_pointer

--- a/spinnman/model/cpu_info.py
+++ b/spinnman/model/cpu_info.py
@@ -258,9 +258,9 @@ class CPUInfo(object):
     @property
     def processor_state_register(self):
         """
-        The value in the processor state register (PSR).
+        The value in the processor state register.
 
-        :return: The PSR value
+        :return: The processor state register value
         :rtype: int
         """
         return self._processor_state_register
@@ -268,9 +268,9 @@ class CPUInfo(object):
     @property
     def stack_pointer(self):
         """
-        The current stack pointer value (SP).
+        The current stack pointer value.
 
-        :return: The SP value
+        :return: The stack pointervalue
         :rtype: int
         """
         return self._stack_pointer
@@ -278,9 +278,9 @@ class CPUInfo(object):
     @property
     def link_register(self):
         """
-        The current link register value (LR).
+        The current link register value.
 
-        :return: The LR value
+        :return: The link register value
         :rtype: int
         """
         return self._link_register

--- a/spinnman/model/router_diagnostics.py
+++ b/spinnman/model/router_diagnostics.py
@@ -51,6 +51,7 @@ class RouterDiagnostics(object):
 
         self._register_values = register_values
 
+    # pylint: disable=wrong-spelling-in-docstring
     @property
     def mon(self):
         """

--- a/spinnman/processes/application_copy_run_process.py
+++ b/spinnman/processes/application_copy_run_process.py
@@ -95,14 +95,14 @@ class ApplicationCopyRunProcess(AbstractMultiConnectionProcess):
         AbstractMultiConnectionProcess.__init__(
             self, next_connection_selector, timeout=timeout)
 
-    def run(self, size, app_id, core_subsets, chksum, wait):
+    def run(self, size, app_id, core_subsets, checksum, wait):
         """
         Run the process.
 
         :param int size: The size of the binary to copy
         :param int app_id: The application id to assign to the running binary
         :param CoreSubsets core_subsets: The cores to load the binary on to
-        :param int chksum: The checksum of the data to test against
+        :param int checksum: The checksum of the data to test against
         :param bool wait:
             Whether to put the binary in "wait" mode or run it straight away
         """
@@ -119,7 +119,7 @@ class ApplicationCopyRunProcess(AbstractMultiConnectionProcess):
                 subset = core_subsets.get_core_subset_for_chip(chip.x, chip.y)
                 self._send_request(AppCopyRun(
                     chip.x, chip.y, chip.parent_link, size, app_id,
-                    subset.processor_ids, chksum, wait))
+                    subset.processor_ids, checksum, wait))
                 eth = (chip.nearest_ethernet_x, chip.nearest_ethernet_y)
                 chips_done[eth].append((chip.x, chip.y))
             self._finish()

--- a/spinnman/processes/get_machine_process.py
+++ b/spinnman/processes/get_machine_process.py
@@ -303,7 +303,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
         Logs all actions except for ignores with unused IP addresses
 
         :param ~spinn_machine.Machine machine:
-            An empty machine to handle wrap-around
+            An empty machine to handle wrap-arounds
         """
         for ignore in IgnoreLink.parse_string(
                 get_config_str_or_none("Machine", "down_links")):
@@ -351,7 +351,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
         Core numbers <= 0 are assumed to be 0 - physical_id
 
         :param ~spinn_machine.Machine machine:
-            An empty machine to handle wrap-around
+            An empty machine to handle wrap-arounds
         """
         # Convert by ip to global
         for ignore in IgnoreCore.parse_string(
@@ -366,7 +366,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
 
     def _preprocess_ignore_chips(self, machine):
         """
-        Processes the collection of ignore chips and discards their chipinfo.
+        Processes the collection of ignore chips and discards their chip info.
 
         Converts any local (x, y IP address) to global (x, y)
 

--- a/spinnman/processes/get_machine_process.py
+++ b/spinnman/processes/get_machine_process.py
@@ -291,7 +291,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
 
     def _process_ignore_links(self, machine):
         """
-        Processes the collection of ignore links to remove then from chipinfo.
+        Processes the collection of ignore links to remove then from chip info.
 
         Converts any local (x, y, IP address) to global (x, y)
 
@@ -303,7 +303,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
         Logs all actions except for ignores with unused IP addresses
 
         :param ~spinn_machine.Machine machine:
-            An empty machine to handle wrap-arounds
+            An empty machine to handle wrap-around
         """
         for ignore in IgnoreLink.parse_string(
                 get_config_str_or_none("Machine", "down_links")):
@@ -351,7 +351,7 @@ class GetMachineProcess(AbstractMultiConnectionProcess):
         Core numbers <= 0 are assumed to be 0 - physical_id
 
         :param ~spinn_machine.Machine machine:
-            An empty machine to handle wrap-arounds
+            An empty machine to handle wrap-around
         """
         # Convert by ip to global
         for ignore in IgnoreCore.parse_string(

--- a/spinnman/spalloc/session.py
+++ b/spinnman/spalloc/session.py
@@ -46,7 +46,8 @@ def _may_renew(method):
         print('{}\n{}\r\n{}\r\n\r\n{}'.format(
             '<<<<<<<<<<<START<<<<<<<<<<<',
             str(response.status_code) + " " + response.reason,
-            '\r\n'.join('{}: {}'.format(*kv) for kv in response.headers.items()),
+            '\r\n'.join('{}: {}'.format(*kv)
+                        for kv in response.headers.items()),
             # Assume we only get textual responses
             str(response.content, "UTF-8") if response.content else ""))
 

--- a/spinnman/spalloc/session.py
+++ b/spinnman/spalloc/session.py
@@ -29,15 +29,16 @@ _debug_pretty_print = False
 
 
 def _may_renew(method):
-    def pp_req(req: requests.PreparedRequest):
+    def pp_req(request: requests.PreparedRequest):
         """
-        :param ~requests.PreparedRequest req:
+        :param ~requests.PreparedRequest request:
         """
         print('{}\n{}\r\n{}\r\n\r\n{}'.format(
             '>>>>>>>>>>>START>>>>>>>>>>>',
-            req.method + ' ' + req.url,
-            '\r\n'.join('{}: {}'.format(*kv) for kv in req.headers.items()),
-            req.body if req.body else ""))
+            request.method + ' ' + request.url,
+            '\r\n'.join('{}: {}'.format(*kv)
+                        for kv in request.headers.items()),
+            request.body if request.body else ""))
 
     def pp_resp(response: requests.Response):
         """

--- a/spinnman/spalloc/session.py
+++ b/spinnman/spalloc/session.py
@@ -39,16 +39,16 @@ def _may_renew(method):
             '\r\n'.join('{}: {}'.format(*kv) for kv in req.headers.items()),
             req.body if req.body else ""))
 
-    def pp_resp(resp: requests.Response):
+    def pp_resp(response: requests.Response):
         """
-        :param ~requests.Response resp:
+        :param ~requests.Response response:
         """
         print('{}\n{}\r\n{}\r\n\r\n{}'.format(
             '<<<<<<<<<<<START<<<<<<<<<<<',
-            str(resp.status_code) + " " + resp.reason,
-            '\r\n'.join('{}: {}'.format(*kv) for kv in resp.headers.items()),
+            str(response.status_code) + " " + response.reason,
+            '\r\n'.join('{}: {}'.format(*kv) for kv in response.headers.items()),
             # Assume we only get textual responses
-            str(resp.content, "UTF-8") if resp.content else ""))
+            str(response.content, "UTF-8") if response.content else ""))
 
     @wraps(method)
     def call(self, *args, **kwargs):

--- a/spinnman/spalloc/session.py
+++ b/spinnman/spalloc/session.py
@@ -139,20 +139,20 @@ class Session:
         return self.__handle_error_or_return(r)
 
     @_may_renew
-    def post(self, url: str, jsonobj: dict, timeout: int = 10,
+    def post(self, url: str, json_dict: dict, timeout: int = 10,
              **kwargs) -> requests.Response:
         """
         Do an HTTP ``POST`` in the session.
 
         :param str url:
         :param int timeout:
-        :param dict jsonobj:
+        :param dict json_dict:
         :rtype: ~requests.Response
         :raise ValueError: If the server rejects a request
         """
         params = kwargs if kwargs else None
         cookies, headers = self._credentials
-        r = requests.post(url, params=params, json=jsonobj,
+        r = requests.post(url, params=params, json=json_dict,
                           cookies=cookies, headers=headers,
                           allow_redirects=False, timeout=timeout)
         logger.debug("POST {} returned {}", url, r.status_code)
@@ -340,8 +340,8 @@ class SessionAware:
     def _get(self, url: str, **kwargs) -> requests.Response:
         return self.__session.get(url, **kwargs)
 
-    def _post(self, url: str, jsonobj: dict, **kwargs) -> requests.Response:
-        return self.__session.post(url, jsonobj, **kwargs)
+    def _post(self, url: str, json_dict: dict, **kwargs) -> requests.Response:
+        return self.__session.post(url, json_dict, **kwargs)
 
     def _put(self, url: str, data: str, **kwargs) -> requests.Response:
         return self.__session.put(url, data, **kwargs)

--- a/spinnman/transceiver/base_transceiver.py
+++ b/spinnman/transceiver/base_transceiver.py
@@ -111,7 +111,7 @@ _POWER_CYCLE_FAILURE_WARNING = (
 
 class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
     """
-    A base for all the code shared by all Version of the Transciever.
+    A base for all the code shared by all Version of the Transceiver.
 
     """
     __slots__ = [

--- a/spinnman/transceiver/virtual5Transceiver.py
+++ b/spinnman/transceiver/virtual5Transceiver.py
@@ -24,7 +24,7 @@ from .version5transceiver import Version5Transceiver
 
 class Virtual5Transceiver(Version5Transceiver):
     """
-    Overwirtes the standard Version 5 Transceiver
+    Overwrites the standard Version 5 Transceiver
     to intercept the sending of messages.
 
     This is just enough different to pass know tests.

--- a/spinnman/utilities/socket_utils.py
+++ b/spinnman/utilities/socket_utils.py
@@ -51,6 +51,7 @@ def get_tcp_socket():
             f"Error setting up socket: {e}") from e
 
 
+# pylint: disable=wrong-spelling-in-docstring
 def set_receive_buffer_size(sock, size):
     """
     Wrapper round setsockopt() system call.


### PR DESCRIPTION
In several cases param names where changed to actual words.

Doc spelling fixes

Adds so spelling ignores
.pylint_dict.txt for words to accept everywhere
- WriteFPGARegister due to SPI and SpI/O
- spinnman/utilities/socket_utils.py due to methods wrapped around



