### PR TITLE
Allow no-reply to count message

### DIFF
--- a/spinnman/messages/scp/impl/count_state_response.py
+++ b/spinnman/messages/scp/impl/count_state_response.py
@@ -34,7 +34,9 @@ class CountStateResponse(AbstractSCPResponse):
     @overrides(AbstractSCPResponse.read_data_bytestring)
     def read_data_bytestring(self, data: bytes, offset: int):
         result = self.scp_response_header.result
-        if result != SCPResult.RC_OK:
+        # We can accept a no-reply response here; that could just mean
+        # that the count wasn't complete (but might be enough anyway)
+        if result != SCPResult.RC_OK and result != SCPResult.RC_P2P_NOREPLY:
             raise SpinnmanUnexpectedResponseCodeException(
                 "CountState", "CMD_COUNT", result.name)
         self._count = _ONE_WORD.unpack_from(data, offset)[0]


### PR DESCRIPTION
The COUNT request can return a P2P_NOREPLY if not all expected chips replied.  This is not fatal, as a count is still included in the response.  Allowing this to not be a failure here means that:
1. The SpiNNMan SCP pipeline will retry before getting to this point, which means the error might go away.
2. If the pipeline retries continue to lead to P2P_NOREPLY, this code will be called eventually; not failing here means we still have a count, but the count can only be smaller than it should be (as some counts didn't come back before the timeout).
3. The count might still be enough to continue if the chips that didn't reply don't matter.  If not, another mechanism will be used to count the cores anyway (i.e. reading all the CPU statuses separately).  If a chip can't be read there, this will be fatal there instead (which is fine).