### PR TITLE
infos_not_in_states method

### DIFF
--- a/spinnman/model/cpu_infos.py
+++ b/spinnman/model/cpu_infos.py
@@ -90,6 +90,20 @@ class CPUInfos(object):
                 for_state.add_info(info)
         return for_state
 
+    def infos_not_in_states(self, states: Iterable[CPUState]) -> 'CPUInfos':
+        """
+        Creates a new CpuInfos object with Just the Infos that match the state.
+
+        :param iterable(~spinnman.model.enums.CPUState) states:
+        :return: New Infos object with the filtered infos if any
+        :rtype: CPUInfos
+        """
+        for_state = CPUInfos()
+        for info in self._cpu_infos.values():
+            if info.state not in states:
+                for_state.add_info(info)
+        return for_state
+
     def get_status_string(self) -> str:
         """
         Get a string indicating the status of the given cores.

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -51,7 +51,6 @@ class TestCpuInfos(unittest.TestCase):
         idle = infos.infos_for_state(CPUState.IDLE)
         self.assertFalse(idle)
 
-
         # the str is for example purpose and may change without notice
         self.assertEqual(infos.get_status_string(),
                          "0:0:1 in state RUNNING\n"

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -43,12 +43,14 @@ class TestCpuInfos(unittest.TestCase):
             "['0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)']", str(finished))
         self.assertTrue(finished)
 
+        finished = infos.infos_not_in_states(
+            [CPUState.RUNNING, CPUState.RUN_TIME_EXCEPTION])
+        self.assertEqual(
+            "['0, 0, 2 (ph: 6)', '1, 0, 1 (ph: 7)']", str(finished))
+
         idle = infos.infos_for_state(CPUState.IDLE)
         self.assertFalse(idle)
 
-        info = infos.get_cpu_info(0, 0, 2)
-        self.assertEqual(
-            "0:0:02 (06) FINISHED           scamp-3            0", str(info))
 
         # the str is for example purpose and may change without notice
         self.assertEqual(infos.get_status_string(),


### PR DESCRIPTION
adds and tests a infos_not_in_states method

This because the CpuInfos iter no linger includes CPUInfo items.

needed for:
