### PR TITLE
Allow count p2p timeout

### DIFF
--- a/spinnman/processes/abstract_multi_connection_process.py
+++ b/spinnman/processes/abstract_multi_connection_process.py
@@ -29,6 +29,7 @@ from .abstract_multi_connection_process_connection_selector import (
 from spinnman.connections.udp_packet_connections import SCAMPConnection
 from spinnman.messages.scp.abstract_messages import (
     AbstractSCPRequest, AbstractSCPResponse)
+from spinnman.messages.scp.enums.scp_result import SCPResult
 #: Type of responses.
 #: :meta private:
 R = TypeVar("R", bound=AbstractSCPResponse)
@@ -53,13 +54,15 @@ class AbstractMultiConnectionProcess(Generic[R]):
         "_intermediate_channel_waits",
         "_n_channels",
         "_n_retries",
+        "_non_fail_retry_codes",
         "_conn_selector",
         "_scp_request_pipelines",
         "_timeout")
 
     def __init__(self, next_connection_selector: ConnectionSelector,
                  n_retries: int = N_RETRIES, timeout: float = SCP_TIMEOUT,
-                 n_channels: int = 8, intermediate_channel_waits: int = 7):
+                 n_channels: int = 8, intermediate_channel_waits: int = 7,
+                 non_fail_retry_codes: Optional[set(SCPResult)] = None):
         """
         :param ConnectionSelector next_connection_selector:
             How to choose the connection.
@@ -74,6 +77,9 @@ class AbstractMultiConnectionProcess(Generic[R]):
         :param int intermediate_channel_waits:
             The maximum number of outstanding message/reply pairs to have on a
             particular connection. Passed to :py:class:`SCPRequestPipeLine`
+        :param Optional[set(SCPResult)] non_fail_retry_codes:
+            Optional set of responses that result in retry but after retrying
+            don't then result in failure even if returned on the last call.
         """
         self._exceptions: List[Exception] = []
         self._tracebacks: List[TracebackType] = []
@@ -86,6 +92,7 @@ class AbstractMultiConnectionProcess(Generic[R]):
         self._n_channels = n_channels
         self._intermediate_channel_waits = intermediate_channel_waits
         self._conn_selector = next_connection_selector
+        self._non_fail_retry_codes = non_fail_retry_codes
 
     def _send_request(self, request: AbstractSCPRequest[R],
                       callback: Optional[Callable[[R], None]] = None,
@@ -98,7 +105,8 @@ class AbstractMultiConnectionProcess(Generic[R]):
                 connection, n_retries=self._n_retries,
                 packet_timeout=self._timeout,
                 n_channels=self._n_channels,
-                intermediate_channel_waits=self._intermediate_channel_waits)
+                intermediate_channel_waits=self._intermediate_channel_waits,
+                non_fail_retry_codes=self._non_fail_retry_codes)
         self._scp_request_pipelines[connection].send_request(
             request, callback, error_callback)
 

--- a/spinnman/processes/abstract_multi_connection_process.py
+++ b/spinnman/processes/abstract_multi_connection_process.py
@@ -17,7 +17,7 @@ import logging
 import sys
 from types import TracebackType
 from typing import (
-    Callable, Dict, Generator, Generic, List, Optional, TypeVar, cast)
+    Callable, Dict, Generator, Generic, List, Optional, TypeVar, cast, Set)
 from typing_extensions import Self, TypeAlias
 from spinn_utilities.log import FormatAdapter
 from spinnman.connections import SCPRequestPipeLine
@@ -62,7 +62,7 @@ class AbstractMultiConnectionProcess(Generic[R]):
     def __init__(self, next_connection_selector: ConnectionSelector,
                  n_retries: int = N_RETRIES, timeout: float = SCP_TIMEOUT,
                  n_channels: int = 8, intermediate_channel_waits: int = 7,
-                 non_fail_retry_codes: Optional[set(SCPResult)] = None):
+                 non_fail_retry_codes: Optional[Set[SCPResult]] = None):
         """
         :param ConnectionSelector next_connection_selector:
             How to choose the connection.
@@ -77,7 +77,7 @@ class AbstractMultiConnectionProcess(Generic[R]):
         :param int intermediate_channel_waits:
             The maximum number of outstanding message/reply pairs to have on a
             particular connection. Passed to :py:class:`SCPRequestPipeLine`
-        :param Optional[set(SCPResult)] non_fail_retry_codes:
+        :param Optional[Set[SCPResult]] non_fail_retry_codes:
             Optional set of responses that result in retry but after retrying
             don't then result in failure even if returned on the last call.
         """

--- a/spinnman/processes/get_n_cores_in_state_process.py
+++ b/spinnman/processes/get_n_cores_in_state_process.py
@@ -14,6 +14,7 @@
 
 from spinnman.messages.scp.impl import CountState
 from .abstract_multi_connection_process import AbstractMultiConnectionProcess
+from spinnman.messages.scp.enums.scp_result import SCPResult
 
 # Timeout for getting core state count; higher due to more waiting needed
 GET_CORE_COUNT_TIMEOUT = 2.0
@@ -29,7 +30,8 @@ class GetNCoresInStateProcess(AbstractMultiConnectionProcess):
         :type connection_selector:
             AbstractMultiConnectionProcessConnectionSelector
         """
-        super().__init__(connection_selector, timeout=GET_CORE_COUNT_TIMEOUT)
+        super().__init__(connection_selector, timeout=GET_CORE_COUNT_TIMEOUT,
+                         non_fail_retry_codes={SCPResult.RC_P2P_NOREPLY})
         self._n_cores = 0
 
     def __handle_response(self, response):

--- a/spinnman/processes/send_single_command_process.py
+++ b/spinnman/processes/send_single_command_process.py
@@ -18,6 +18,7 @@ from spinnman.messages.scp.abstract_messages import AbstractSCPResponse
 from spinnman.messages.scp.abstract_messages import AbstractSCPRequest
 from .abstract_multi_connection_process_connection_selector import (
     ConnectionSelector)
+from spinnman.messages.scp.enums.scp_result import SCPResult
 #: Type of responses.
 #: :meta private:
 R = TypeVar("R", bound=AbstractSCPResponse)
@@ -30,7 +31,8 @@ class SendSingleCommandProcess(AbstractMultiConnectionProcess, Generic[R]):
     __slots__ = ("_response", )
 
     def __init__(self, connection_selector: ConnectionSelector,
-                 n_retries: int = 3, timeout: float = SCP_TIMEOUT):
+                 n_retries: int = 3, timeout: float = SCP_TIMEOUT,
+                 non_fail_retry_codes: Optional[set(SCPResult)] = None):
         """
         :param ConnectionSelector connection_selector:
         :param int n_retries:
@@ -39,9 +41,13 @@ class SendSingleCommandProcess(AbstractMultiConnectionProcess, Generic[R]):
         :param float timeout:
             The timeout, in seconds. Passed to
             :py:class:`SCPRequestPipeLine`
+        :param Optional[set(SCPResult)] non_fail_retry_codes:
+            Optional set of responses that result in retry but after retrying
+            don't then result in failure even if returned on the last call.
         """
         super().__init__(
-            connection_selector, n_retries=n_retries, timeout=timeout)
+            connection_selector, n_retries=n_retries, timeout=timeout,
+            non_fail_retry_codes=non_fail_retry_codes)
         self._response: Optional[R] = None
 
     def __handle_response(self, response: R):

--- a/spinnman/processes/send_single_command_process.py
+++ b/spinnman/processes/send_single_command_process.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar, Set
 from .abstract_multi_connection_process import AbstractMultiConnectionProcess
 from spinnman.constants import SCP_TIMEOUT
 from spinnman.messages.scp.abstract_messages import AbstractSCPResponse
@@ -32,7 +32,7 @@ class SendSingleCommandProcess(AbstractMultiConnectionProcess, Generic[R]):
 
     def __init__(self, connection_selector: ConnectionSelector,
                  n_retries: int = 3, timeout: float = SCP_TIMEOUT,
-                 non_fail_retry_codes: Optional[set(SCPResult)] = None):
+                 non_fail_retry_codes: Optional[Set[SCPResult]] = None):
         """
         :param ConnectionSelector connection_selector:
         :param int n_retries:
@@ -41,7 +41,7 @@ class SendSingleCommandProcess(AbstractMultiConnectionProcess, Generic[R]):
         :param float timeout:
             The timeout, in seconds. Passed to
             :py:class:`SCPRequestPipeLine`
-        :param Optional[set(SCPResult)] non_fail_retry_codes:
+        :param Optional[Set[SCPResult]] non_fail_retry_codes:
             Optional set of responses that result in retry but after retrying
             don't then result in failure even if returned on the last call.
         """


### PR DESCRIPTION
These changes allow the P2P timeout for counting core statuses to get through the rest of the mechanisms.

Tested by: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/allow_count_p2p_timeout/2/pipeline/