### PR TITLE
Allow odd RTE values, as crashes can cause oddities!

### DIFF
--- a/spinnman/model/enums/run_time_error.py
+++ b/spinnman/model/enums/run_time_error.py
@@ -61,3 +61,5 @@ class RunTimeError(Enum):
     API = 19
     #: Sark software version conflict
     SARK_VERSRION_INCORRECT = 20
+    #: Unhandled exception
+    UNRECOGNISED = 99999


### PR DESCRIPTION
This lets odd RTE values pass, but be reported.  Without this, an odd RTE value gives very little information...