### PR TITLE
typing unittests

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -27,6 +27,5 @@ jobs:
       coverage-package: spinnman
       flake8-packages: spinnman unittests spinnman_integration_tests
       pylint-packages: spinnman
-      mypy-packages: unittests spinnman_integration_tests
-      mypy-full_packages: spinnman
+      mypy-full_packages: spinnman unittests spinnman_integration_tests
     secrets: inherit

--- a/mypyd.bash
+++ b/mypyd.bash
@@ -22,4 +22,4 @@
 utils="../SpiNNUtils/spinn_utilities"
 machine="../SpiNNMachine/spinn_machine"
 
-mypy --python-version 3.8 --disallow-untyped-defs $utils $machine spinnman
+mypy --python-version 3.8 --disallow-untyped-defs $utils $machine spinnman unittests spinnman_integration_tests

--- a/spinnman/transceiver/base_transceiver.py
+++ b/spinnman/transceiver/base_transceiver.py
@@ -151,7 +151,7 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
         "_udp_scamp_connections",
         "_width")
 
-    def __init__(self, connections: Optional[List[Connection]] = None,
+    def __init__(self, connections: Optional[Iterable[Connection]] = None,
                  power_cycle: bool = False):
         """
         :param list(Connection) connections:
@@ -178,7 +178,7 @@ class BaseTransceiver(ExtendableTransceiver, metaclass=AbstractBase):
         # A set of the original connections - used to determine what can
         # be closed
         if connections is None:
-            connections = list()
+            connections = set()
 
         # A set of all connection - used for closing
         self._all_connections = set(connections)

--- a/spinnman/transceiver/transceiver_factory.py
+++ b/spinnman/transceiver/transceiver_factory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import (List, Optional)
+from typing import (Iterable, List, Optional)
 from spinn_utilities.log import FormatAdapter
 from spinn_machine.version.version_3 import Version3
 from spinn_machine.version.version_5 import Version5
@@ -110,7 +110,7 @@ def create_transceiver_from_hostname(
 
 
 def create_transceiver_from_connections(
-        connections: List[Connection], virtual: bool = False,
+        connections: Iterable[Connection], virtual: bool = False,
         power_cycle: bool = False, extended: bool = False) -> Transceiver:
     """
     Create a Transceiver with these connections

--- a/spinnman/transceiver/version3transceiver.py
+++ b/spinnman/transceiver/version3transceiver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Iterable, Optional
 from spinn_utilities.overrides import overrides
 from spinnman.connections.abstract_classes import Connection
 from spinnman.data import SpiNNManDataView
@@ -27,7 +27,7 @@ class Version3Transceiver(BaseTransceiver):
     """
 
     @overrides(BaseTransceiver.__init__)
-    def __init__(self, connections: Optional[List[Connection]] = None,
+    def __init__(self, connections: Optional[Iterable[Connection]] = None,
                  power_cycle: bool = False):
         super().__init__(connections, power_cycle=power_cycle)
         assert SpiNNManDataView.get_machine_version().number == 3

--- a/spinnman/transceiver/version5transceiver.py
+++ b/spinnman/transceiver/version5transceiver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Iterable, Optional
 from spinn_utilities.overrides import overrides
 from spinnman.connections.abstract_classes import Connection
 from spinnman.data import SpiNNManDataView
@@ -27,7 +27,7 @@ class Version5Transceiver(BaseTransceiver):
     """
 
     @overrides(BaseTransceiver.__init__)
-    def __init__(self, connections: Optional[List[Connection]] = None,
+    def __init__(self, connections: Optional[Iterable[Connection]] = None,
                  power_cycle: bool = False):
         super().__init__(connections, power_cycle)
         assert SpiNNManDataView.get_machine_version().number == 5

--- a/spinnman_integration_tests/test_job.py
+++ b/spinnman_integration_tests/test_job.py
@@ -23,13 +23,13 @@ from spinnman.spalloc import SpallocClient, SpallocState
 
 class TestTransceiver(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
-        set_config("Machine", "version", FIVE)
+        set_config("Machine", "version", str(FIVE))
         self.spalloc_url = "https://spinnaker.cs.man.ac.uk/spalloc"
         self.spalloc_machine = "SpiNNaker1M"
 
-    def test_create_job(self):
+    def test_create_job(self) -> None:
         try:
             client = SpallocClient(self.spalloc_url)
         except ConnectionError as ex:
@@ -48,7 +48,7 @@ class TestTransceiver(unittest.TestCase):
 
             txrx = job.create_transceiver()
 
-            dims = txrx._get_machine_dimensions()
+            dims = txrx._get_machine_dimensions()  # type: ignore[attr-defined]
             # May be 12 as we only asked for 2 boards
             self.assertGreaterEqual(dims.height, 12)
             self.assertGreaterEqual(dims.width, 12)

--- a/unittests/connection_tests/test_udp_boot_connection.py
+++ b/unittests/connection_tests/test_udp_boot_connection.py
@@ -19,10 +19,10 @@ from spinnman.config_setup import unittest_setup
 
 class MyTestCase(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_something(self):
+    def test_something(self) -> None:
         udp_connect = BootConnection()
         self.assertIsNotNone(udp_connect)
 

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -22,10 +22,10 @@ from spinnman.transceiver import MockableTransceiver
 
 class TestData(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_setup(self):
+    def test_setup(self) -> None:
         # What happens before setup depends on the previous test
         # Use manual_check to verify this without dependency
         SpiNNManDataWriter.setup()

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -32,7 +32,7 @@ class TestData(unittest.TestCase):
         with self.assertRaises(DataNotYetAvialable):
             SpiNNManDataView.get_transceiver()
 
-    def test_transceiver(self):
+    def test_transceiver(self) -> None:
         writer = SpiNNManDataWriter.setup()
         with self.assertRaises(DataNotYetAvialable):
             SpiNNManDataView.get_transceiver()
@@ -41,4 +41,4 @@ class TestData(unittest.TestCase):
         SpiNNManDataView.get_transceiver()
         self.assertTrue(SpiNNManDataView.has_transceiver())
         with self.assertRaises(TypeError):
-            writer.set_transceiver("bacon")
+            writer.set_transceiver("bacon")  # type: ignore[arg-type]

--- a/unittests/messages/test_eieio_type.py
+++ b/unittests/messages/test_eieio_type.py
@@ -20,9 +20,9 @@ from spinnman.messages.eieio import EIEIOType
 
 class TestEIEIOType(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_get(self):
+    def test_get(self) -> None:
         EIEIOType(2)
         EIEIOType["KEY_32_BIT"]

--- a/unittests/model_tests/test_abstract_process.py
+++ b/unittests/model_tests/test_abstract_process.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+from typing_extensions import Never
 from spinn_utilities.config_holder import set_config
+from spinn_utilities.overrides import overrides
 from spinn_machine.version.version_strings import VersionStrings
 from spinnman.processes.abstract_multi_connection_process import (
     AbstractMultiConnectionProcess)
@@ -26,20 +29,23 @@ import pytest
 
 
 class MockProcess(AbstractMultiConnectionProcess):
-    def test(self):
+    def test(self) -> None:
         with self._collect_responses(print_exception=True):
             self._send_request(ReadMemory((0, 0, 0), 0, 4))
 
 
 class MockConnection(SCAMPConnection):
-    def send(self, data):
+
+    @overrides(SCAMPConnection.send)
+    def send(self, data: bytes) -> None:
         pass
 
-    def receive_scp_response(self, timeout=1.0):
+    @overrides(SCAMPConnection.receive_scp_response)
+    def receive_scp_response(self, timeout: Optional[float] = 1.0) -> Never:
         raise SpinnmanTimeoutException("Test", timeout)
 
 
-def test_error_print():
+def test_error_print() -> None:
     unittest_setup()
     set_config("Machine", "versions", VersionStrings.ANY.text)
     connection = MockConnection(0, 0)

--- a/unittests/model_tests/test_core_subset_model.py
+++ b/unittests/model_tests/test_core_subset_model.py
@@ -19,10 +19,10 @@ from spinnman.config_setup import unittest_setup
 
 class TestCoreSubset(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_core_subset(self):
+    def test_create_new_core_subset(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         self.assertEqual(cs.x, 0)
@@ -31,11 +31,11 @@ class TestCoreSubset(unittest.TestCase):
             self.assertIn(proc, proc_list)
         self.assertEqual(len([x for x in cs.processor_ids]), len(proc_list))
 
-    def test_create_new_core_subset_duplicate_processors(self):
+    def test_create_new_core_subset_duplicate_processors(self) -> None:
         cs = CoreSubset(0, 0, [0, 1, 1, 2, 3, 5, 8, 13])
         self.assertIsNotNone(cs, "must make instance of CoreSubset")
 
-    def test_create_empty_core_subset_add_processor(self):
+    def test_create_empty_core_subset_add_processor(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, [])
         self.assertEqual(cs.x, 0)

--- a/unittests/model_tests/test_core_subsets_model.py
+++ b/unittests/model_tests/test_core_subsets_model.py
@@ -19,14 +19,14 @@ from spinnman.config_setup import unittest_setup
 
 class TestCoreSubsets(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_default_core_subsets(self):
+    def test_create_new_default_core_subsets(self) -> None:
         css = CoreSubsets()
         self.assertIsNotNone(css, "must make instance of CoreSubsets")
 
-    def test_create_new_core_subsets(self):
+    def test_create_new_core_subsets(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets([cs])
@@ -34,25 +34,25 @@ class TestCoreSubsets(unittest.TestCase):
         for core_subset in css.core_subsets:
             self.assertIn(core_subset, [cs])
 
-    def test_add_processor_duplicate_processor(self):
+    def test_add_processor_duplicate_processor(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets([cs])
         css.add_processor(0, 0, 0)
 
-    def test_add_processor_duplicate_processor_different_chip(self):
+    def test_add_processor_duplicate_processor_different_chip(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets([cs])
         css.add_processor(0, 1, 0)
 
-    def test_add_core_subset_duplicate_core_subset(self):
+    def test_add_core_subset_duplicate_core_subset(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets([cs])
         css.add_core_subset(cs)
 
-    def test_add_core_subset(self):
+    def test_add_core_subset(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets()
@@ -61,7 +61,7 @@ class TestCoreSubsets(unittest.TestCase):
         for core_subset in css.core_subsets:
             self.assertIn(core_subset, [cs])
 
-    def test_add_processor(self):
+    def test_add_processor(self) -> None:
         proc_list = [0, 1, 2, 3, 5, 8, 13]
         cs = CoreSubset(0, 0, proc_list)
         css = CoreSubsets()

--- a/unittests/model_tests/test_cpu_infos.py
+++ b/unittests/model_tests/test_cpu_infos.py
@@ -20,10 +20,10 @@ from spinnman.model.enums.cpu_state import CPUState
 
 class TestCpuInfos(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_cpu_infos(self):
+    def test_cpu_infos(self) -> None:
         infos = CPUInfos()
 
         infos.add_info(CPUInfo.mock_info(0, 0, 1, 5, CPUState.RUNNING))
@@ -61,7 +61,7 @@ class TestCpuInfos(unittest.TestCase):
                          "    r4=0, r5=0, r6=0, r7=0\n"
                          "    PSR=0, SP=0, LR=0\n")
 
-    def test_add_info(self):
+    def test_add_info(self) -> None:
         infos1 = CPUInfos()
         infos1.add_info(CPUInfo.mock_info(0, 0, 1, 5, CPUState.RUNNING))
         infos1.add_info(CPUInfo.mock_info(0, 0, 2, 6, CPUState.FINISHED))

--- a/unittests/model_tests/test_io_buff_model.py
+++ b/unittests/model_tests/test_io_buff_model.py
@@ -19,10 +19,10 @@ from spinnman.config_setup import unittest_setup
 
 class TestingIOBuf(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_buf(self):
+    def test_new_buf(self) -> None:
         iobuf = IOBuffer(0, 1, 2, 'Everything failed on chip.')
         self.assertIsNotNone(iobuf)
         self.assertEqual(iobuf.x, 0)

--- a/unittests/model_tests/test_iptag_model.py
+++ b/unittests/model_tests/test_iptag_model.py
@@ -20,10 +20,10 @@ from spinnman.config_setup import unittest_setup
 
 class TestIptag(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_iptag(self):
+    def test_new_iptag(self) -> None:
         board_config = BoardTestConfiguration()
         board_config.set_up_remote_board(version=5)
         ip = "8.8.8.8"

--- a/unittests/model_tests/test_machine_dimensions_model.py
+++ b/unittests/model_tests/test_machine_dimensions_model.py
@@ -19,10 +19,10 @@ from spinnman.config_setup import unittest_setup
 
 class TestMachineDimensionsModel(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_iptag(self):
+    def test_new_iptag(self) -> None:
         x_max = 253
         y_max = 220
         machine_dim = MachineDimensions(x_max, y_max)

--- a/unittests/model_tests/test_retrieving_values_from_enum_models.py
+++ b/unittests/model_tests/test_retrieving_values_from_enum_models.py
@@ -20,17 +20,17 @@ from spinnman.config_setup import unittest_setup
 
 class TestingEnums(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_mailbox_command_enum(self):
+    def test_mailbox_command_enum(self) -> None:
         self.assertEqual(MailboxCommand.SHM_IDLE.value, 0)
         self.assertEqual(MailboxCommand.SHM_MSG.value, 1)
         self.assertEqual(MailboxCommand.SHM_NOP.value, 2)
         self.assertEqual(MailboxCommand.SHM_SIGNAL.value, 3)
         self.assertEqual(MailboxCommand.SHM_CMD.value, 4)
 
-    def test_cpu_state_enum(self):
+    def test_cpu_state_enum(self) -> None:
         self.assertEqual(CPUState.DEAD.value, 0)
         self.assertEqual(CPUState.POWERED_DOWN.value, 1)
         self.assertEqual(CPUState.RUN_TIME_EXCEPTION.value, 2)
@@ -47,7 +47,7 @@ class TestingEnums(unittest.TestCase):
         self.assertEqual(CPUState.FINISHED.value, 11)
         self.assertEqual(CPUState.IDLE.value, 15)
 
-    def test_run_time_error_enum(self):
+    def test_run_time_error_enum(self) -> None:
         self.assertEqual(RunTimeError.NONE.value, 0)
         self.assertEqual(RunTimeError.RESET.value, 1)
         self.assertEqual(RunTimeError.UNDEF.value, 2)
@@ -66,7 +66,7 @@ class TestingEnums(unittest.TestCase):
         self.assertEqual(RunTimeError.SWERR.value, 13)
         self.assertEqual(RunTimeError.IOBUF.value, 14)
 
-    def test_router_diagnostics_enum(self):
+    def test_router_diagnostics_enum(self) -> None:
         self.assertEqual(ROUTER_REGISTER_REGISTERS.LOC_MC.value, 0)
         self.assertEqual(ROUTER_REGISTER_REGISTERS.EXT_MC.value, 1)
         self.assertEqual(ROUTER_REGISTER_REGISTERS.LOC_PP.value, 2)

--- a/unittests/model_tests/test_version_info_model.py
+++ b/unittests/model_tests/test_version_info_model.py
@@ -21,10 +21,10 @@ from spinnman.exceptions import SpinnmanInvalidParameterException
 
 class TestVersionInfo(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_retrieving_bits_from_version_data(self):
+    def test_retrieving_bits_from_version_data(self) -> None:
         p2p_adr = 0xf0a1
         phys_cpu = 0xff
         virt_cpu = 0x3b
@@ -48,7 +48,7 @@ class TestVersionInfo(unittest.TestCase):
         self.assertEqual(vi.build_date, build_date)
         self.assertEqual(vi.version_string, "my/spinnaker")
 
-    def test_retrieving_bits_from_invalid_version_data_format(self):
+    def test_retrieving_bits_from_invalid_version_data_format(self) -> None:
         with self.assertRaises(SpinnmanInvalidParameterException):
             p2p_adr = 0xf0a1
             phys_cpu = 0xff
@@ -67,7 +67,7 @@ class TestVersionInfo(unittest.TestCase):
             # Should be unreachable, but if it ever works, should pass this
             self.assertIsNotNone(vi)
 
-    def test_retrieving_bits_from_invalid_sized_version_data(self):
+    def test_retrieving_bits_from_invalid_sized_version_data(self) -> None:
         with self.assertRaises(SpinnmanInvalidParameterException):
             p2p_adr = 0xf0a1
             phys_cpu = 0xff

--- a/unittests/processes_test/test_most_direct_connections_selector.py
+++ b/unittests/processes_test/test_most_direct_connections_selector.py
@@ -18,10 +18,10 @@ from spinnman.processes import MostDirectConnectionSelector
 
 class TestCpuInfos(unittest.TestCase):
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         with self.assertRaises(StopIteration):
             MostDirectConnectionSelector([])
 
-    def test_one(self):
-        c = SCAMPConnection("127.0.0.0")
+    def test_one(self) -> None:
+        c = SCAMPConnection(local_host="127.0.0.0")
         MostDirectConnectionSelector([c])

--- a/unittests/processes_test/test_most_direct_connections_selector.py
+++ b/unittests/processes_test/test_most_direct_connections_selector.py
@@ -23,5 +23,5 @@ class TestCpuInfos(unittest.TestCase):
             MostDirectConnectionSelector([])
 
     def test_one(self) -> None:
-        c = SCAMPConnection(local_host="127.0.0.0")
+        c = SCAMPConnection()
         MostDirectConnectionSelector([c])

--- a/unittests/scp_tests/test_count_state_response.py
+++ b/unittests/scp_tests/test_count_state_response.py
@@ -24,10 +24,10 @@ from spinnman.messages.sdp import SDPFlag
 
 class TestCPUStateResponse(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_count_state_response(self):
+    def test_new_count_state_response(self) -> None:
         response = CountStateResponse()
         # SCP Stuff
         rc = SCPResult.RC_OK.value
@@ -48,7 +48,7 @@ class TestCPUStateResponse(unittest.TestCase):
         response.read_bytestring(data, 0)
         self.assertEqual(response.count, 5)
 
-    def test_new_count_state_response_response_not_ok(self):
+    def test_new_count_state_response_response_not_ok(self) -> None:
         with self.assertRaises(SpinnmanUnexpectedResponseCodeException):
             response = CountStateResponse()
             # SCP Stuff

--- a/unittests/scp_tests/test_scp_check_ok_response.py
+++ b/unittests/scp_tests/test_scp_check_ok_response.py
@@ -23,16 +23,17 @@ from spinnman.messages.sdp import SDPFlag
 
 class TestOkResponse(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_scp_check_ok_response(self):
+    def test_new_scp_check_ok_response(self) -> None:
         CheckOKResponse("Testing operation", "Testing command")
 
-    def _encode_addr_tuple(self, dest_port, dest_cpu, src_port, src_cpu):
+    def _encode_addr_tuple(self, dest_port: int, dest_cpu: int,
+                           src_port: int, src_cpu: int) -> int:
         return dest_port << 13 | dest_cpu << 8 | src_port << 5 | src_cpu
 
-    def test_read_ok_response(self):
+    def test_read_ok_response(self) -> None:
         scp = CheckOKResponse("Testing operation", "Testing command")
         result = SCPResult.RC_OK.value
         flags = SDPFlag.REPLY_NOT_EXPECTED.value
@@ -60,7 +61,7 @@ class TestOkResponse(unittest.TestCase):
                                   dest_x_y_short, src_x_y_short, result, seq)
         scp.read_bytestring(byte_stream, 0)
 
-    def test_not_ok_response(self):
+    def test_not_ok_response(self) -> None:
         with self.assertRaises(SpinnmanUnexpectedResponseCodeException):
             scp = CheckOKResponse("Testing operation", "Testing command")
             result = SCPResult.RC_TIMEOUT.value

--- a/unittests/scp_tests/test_scp_enums.py
+++ b/unittests/scp_tests/test_scp_enums.py
@@ -23,17 +23,17 @@ from spinnman.messages.scp.enums.signal import SignalType
 
 class TestSCPEnums(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_iptag(self):
+    def test_iptag(self) -> None:
         self.assertEqual(IPTagCommand.NEW.value, 0)
         self.assertEqual(IPTagCommand.SET.value, 1)
         self.assertEqual(IPTagCommand.GET.value, 2)
         self.assertEqual(IPTagCommand.CLR.value, 3)
         self.assertEqual(IPTagCommand.TTO.value, 4)
 
-    def test_command(self):
+    def test_command(self) -> None:
         self.assertEqual(SCPCommand.CMD_VER.value, 0)
         self.assertEqual(SCPCommand.CMD_RUN.value, 1)
         self.assertEqual(SCPCommand.CMD_READ.value, 2)
@@ -67,7 +67,7 @@ class TestSCPEnums(unittest.TestCase):
         self.assertEqual(SCPCommand.CMD_BMP_POWER.value, 57)
         self.assertEqual(SCPCommand.CMD_TUBE.value, 64)
 
-    def test_result(self):
+    def test_result(self) -> None:
         self.assertEqual(SCPResult.RC_OK.value, 0x80)
         self.assertEqual(SCPResult.RC_LEN.value, 0x81)
         self.assertEqual(SCPResult.RC_SUM.value, 0x82)
@@ -88,7 +88,7 @@ class TestSCPEnums(unittest.TestCase):
 
         self.assertEqual(SCPResult.RC_PKT_TX.value, 0x8F)
 
-    def test_signal(self):
+    def test_signal(self) -> None:
         self.assertEqual(Signal.INITIALISE.value, 0)
         self.assertEqual(Signal.POWER_DOWN.value, 1)
         self.assertEqual(Signal.STOP.value, 2)

--- a/unittests/scp_tests/test_scp_message_assembly.py
+++ b/unittests/scp_tests/test_scp_message_assembly.py
@@ -21,30 +21,30 @@ from spinnman.messages.scp.impl import GetVersion, ReadLink, ReadMemory
 
 class TestSCPMessageAssembly(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_scp_header(self):
+    def test_create_new_scp_header(self) -> None:
         header = SCPRequestHeader(SCPCommand.CMD_VER)
 
         self.assertEqual(header.command, SCPCommand.CMD_VER)
         self.assertEqual(header.sequence, 0)
 
-    def test_create_new_ver_scp_pkt(self):
+    def test_create_new_ver_scp_pkt(self) -> None:
         scp = GetVersion(0, 0, 0)
         self.assertEqual(scp.argument_1, None)
         self.assertEqual(scp.argument_2, None)
         self.assertEqual(scp.argument_3, None)
         self.assertEqual(scp.data, None)
 
-    def test_create_new_link_scp_pkt(self):
+    def test_create_new_link_scp_pkt(self) -> None:
         scp = ReadLink((0, 0, 0), 0, 0, 256)
         self.assertEqual(scp.argument_1, 0)
         self.assertEqual(scp.argument_2, 256)
         self.assertEqual(scp.argument_3, 0)
         self.assertEqual(scp.data, None)
 
-    def test_create_new_memory_scp_pkt(self):
+    def test_create_new_memory_scp_pkt(self) -> None:
         scp = ReadMemory((0, 0, 0), 0, 256)
         self.assertEqual(scp.argument_1, 0)
         self.assertEqual(scp.argument_2, 256)

--- a/unittests/scp_tests/test_scp_version_request.py
+++ b/unittests/scp_tests/test_scp_version_request.py
@@ -20,10 +20,10 @@ from spinnman.messages.scp.enums import SCPCommand
 
 class TestSCPVersionRequest(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_version_request(self):
+    def test_new_version_request(self) -> None:
         ver_request = GetVersion(0, 1, 2)
         self.assertEqual(ver_request.scp_request_header.command,
                          SCPCommand.CMD_VER)

--- a/unittests/scp_tests/test_scp_version_response.py
+++ b/unittests/scp_tests/test_scp_version_response.py
@@ -22,13 +22,13 @@ from spinnman.messages.sdp import SDPFlag
 
 class TestSCPVersionResponse(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_new_scp_version_response(self):
+    def test_new_scp_version_response(self) -> None:
         GetVersionResponse()
 
-    def test_read_scp_response(self):
+    def test_read_scp_response(self) -> None:
         response = GetVersionResponse()
         # y
         # SCP Stuff

--- a/unittests/sdp_tests/test_eieio_enums.py
+++ b/unittests/sdp_tests/test_eieio_enums.py
@@ -19,10 +19,10 @@ from spinnman.messages.eieio import EIEIOPrefix, EIEIOType
 
 class TestEIEIOEnums(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_eieio_prefix(self):
+    def test_eieio_prefix(self) -> None:
         self.assertEqual(EIEIOPrefix.LOWER_HALF_WORD.value, 0)
         self.assertEqual(EIEIOPrefix(0), EIEIOPrefix.LOWER_HALF_WORD)
 
@@ -31,7 +31,7 @@ class TestEIEIOEnums(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: EIEIOPrefix(2))
 
-    def test_eieio_type(self):
+    def test_eieio_type(self) -> None:
         self.assertEqual(EIEIOType.KEY_16_BIT.value, 0)
         self.assertEqual(EIEIOType.KEY_16_BIT.encoded_value, 0)
         self.assertEqual(EIEIOType.KEY_16_BIT.key_bytes, 2)

--- a/unittests/sdp_tests/test_sdp_enums.py
+++ b/unittests/sdp_tests/test_sdp_enums.py
@@ -19,10 +19,10 @@ from spinnman.messages.sdp.sdp_flag import SDPFlag
 
 class TestSDPEnums(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_sdp_flag(self):
+    def test_sdp_flag(self) -> None:
         self.assertEqual(SDPFlag.REPLY_NOT_EXPECTED.value, 0x7)
         self.assertEqual(SDPFlag.REPLY_EXPECTED.value, 0x87)
 

--- a/unittests/test_boot_message_assembly.py
+++ b/unittests/test_boot_message_assembly.py
@@ -20,10 +20,10 @@ from spinnman.messages.spinnaker_boot import SpinnakerBootOpCode
 
 class TestSpiNNakerBootMessage(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_boot_message(self):
+    def test_create_new_boot_message(self) -> None:
         msg = boot_msg.SpinnakerBootMessage(SpinnakerBootOpCode.HELLO, 0, 0, 0)
         self.assertEqual(msg.data, None)
         self.assertEqual(msg.opcode, SpinnakerBootOpCode.HELLO)

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -21,10 +21,10 @@ from spinnman.config_setup import unittest_setup
 
 class TestCfgChecker(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_config_checks(self):
+    def test_config_checks(self) -> None:
         unittests = os.path.dirname(__file__)
         spinnman_dir = spinnman.__path__[0]
         run_config_checks(directories=[spinnman_dir, unittests])

--- a/unittests/test_import_all_test.py
+++ b/unittests/test_import_all_test.py
@@ -21,7 +21,7 @@ class ImportAllModule(unittest.TestCase):
 
     # no unittest_setup to check all imports work without it
 
-    def test_import_all(self):
+    def test_import_all(self) -> None:
         if os.environ.get('CONTINUOUS_INTEGRATION', 'false').lower() == 'true':
             package_loader.load_module("spinnman", remove_pyc_files=False)
         else:

--- a/unittests/test_multicast_message_assembly.py
+++ b/unittests/test_multicast_message_assembly.py
@@ -19,15 +19,15 @@ import spinnman.messages.multicast_message as multicast_msg
 
 class TestMulticastMessage(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_multicast_message_without_payload(self):
+    def test_create_new_multicast_message_without_payload(self) -> None:
         msg = multicast_msg.MulticastMessage(1)
         self.assertEqual(msg.key, 1)
         self.assertEqual(msg.payload, None)
 
-    def test_create_new_multicast_message_with_payload(self):
+    def test_create_new_multicast_message_with_payload(self) -> None:
         msg = multicast_msg.MulticastMessage(1, 100)
         self.assertEqual(msg.key, 1)
         self.assertEqual(msg.payload, 100)

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -16,7 +16,6 @@ import unittest
 import struct
 
 from spinn_utilities.config_holder import set_config
-from spinn_utilities.overrides import overrides
 
 from spinn_machine.version.version_strings import VersionStrings
 
@@ -39,11 +38,6 @@ class MockExtendedTransceiver(MockableTransceiver, ExtendedTransceiver):
 
     def _where_is_xy(self, x: int, y: int) -> None:
         return None
-
-    #@property
-    #@overrides(MockableTransceiver.scamp_connection_selector)
-    #def scamp_connection_selector(self) -> ConnectionSelector:
-    #    raise NotImplementedError
 
 
 class TestTransceiver(unittest.TestCase):
@@ -75,10 +69,11 @@ class TestTransceiver(unittest.TestCase):
         trans = create_transceiver_from_hostname(self.board_config.remotehost)
         SpiNNManDataWriter.mock().set_machine(trans.get_machine_details())
         version = SpiNNManDataView.get_machine_version()
-        dims = trans._get_machine_dimensions() # type: ignore[attr-defined]
-        self.assertEqual(version.board_shape,            (dims.width, dims.height))
+        dims = trans._get_machine_dimensions()  # type: ignore[attr-defined]
+        self.assertEqual(version.board_shape,
+                         (dims.width, dims.height))
 
-        connections = trans._scamp_connections # type: ignore[attr-defined]
+        connections = trans._scamp_connections  # type: ignore[attr-defined]
         assert any(c.is_connected() for c in connections)
         print(trans._get_scamp_version())  # type: ignore[attr-defined]
         print(trans.get_cpu_infos())

--- a/unittests/test_transceiver.py
+++ b/unittests/test_transceiver.py
@@ -14,8 +14,12 @@
 
 import unittest
 import struct
+
 from spinn_utilities.config_holder import set_config
+from spinn_utilities.overrides import overrides
+
 from spinn_machine.version.version_strings import VersionStrings
+
 from spinnman.config_setup import unittest_setup
 from spinnman.data import SpiNNManDataView
 from spinnman.data.spinnman_data_writer import SpiNNManDataWriter
@@ -36,17 +40,19 @@ class MockExtendedTransceiver(MockableTransceiver, ExtendedTransceiver):
     def _where_is_xy(self, x: int, y: int) -> None:
         return None
 
-    def scamp_connection_selector(self):
-        raise NotImplementedError
+    #@property
+    #@overrides(MockableTransceiver.scamp_connection_selector)
+    #def scamp_connection_selector(self) -> ConnectionSelector:
+    #    raise NotImplementedError
 
 
 class TestTransceiver(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
         self.board_config = BoardTestConfiguration()
 
-    def test_create_new_transceiver_to_board(self):
+    def test_create_new_transceiver_to_board(self) -> None:
         self.board_config.set_up_remote_board()
         connections = list()
         connections.append(SCAMPConnection(
@@ -55,7 +61,7 @@ class TestTransceiver(unittest.TestCase):
         trans.get_connections() == connections
         trans.close()
 
-    def test_create_new_transceiver_one_connection(self):
+    def test_create_new_transceiver_one_connection(self) -> None:
         self.board_config.set_up_remote_board()
         connections = set()
         connections.add(SCAMPConnection(
@@ -64,26 +70,25 @@ class TestTransceiver(unittest.TestCase):
         self.assertSetEqual(connections, trans.get_connections())
         trans.close()
 
-    def test_retrieving_machine_details(self):
+    def test_retrieving_machine_details(self) -> None:
         self.board_config.set_up_remote_board()
         trans = create_transceiver_from_hostname(self.board_config.remotehost)
         SpiNNManDataWriter.mock().set_machine(trans.get_machine_details())
         version = SpiNNManDataView.get_machine_version()
-        self.assertEqual(
-            version.board_shape,
-            (trans._get_machine_dimensions().width,
-             trans._get_machine_dimensions().height))
+        dims = trans._get_machine_dimensions() # type: ignore[attr-defined]
+        self.assertEqual(version.board_shape,            (dims.width, dims.height))
 
-        assert any(c.is_connected() for c in trans._scamp_connections)
-        print(trans._get_scamp_version())
+        connections = trans._scamp_connections # type: ignore[attr-defined]
+        assert any(c.is_connected() for c in connections)
+        print(trans._get_scamp_version())  # type: ignore[attr-defined]
         print(trans.get_cpu_infos())
 
-    def test_boot_board(self):
+    def test_boot_board(self) -> None:
         self.board_config.set_up_remote_board()
         trans = create_transceiver_from_hostname(self.board_config.remotehost)
-        trans._boot_board()
+        trans._boot_board()  # type: ignore[attr-defined]
 
-    def test_set_watch_dog(self):
+    def test_set_watch_dog(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         connections = []
         connections.append(SCAMPConnection(remote_host=None))

--- a/unittests/test_version.py
+++ b/unittests/test_version.py
@@ -25,38 +25,38 @@ class Test(unittest.TestCase):
     """ Tests for the SCAMP version comparison
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_version_same(self):
+    def test_version_same(self) -> None:
         self.assertTrue(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2])))
 
-    def test_major_version_too_big(self):
+    def test_major_version_too_big(self) -> None:
         self.assertFalse(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0] + 1, 0, 0)))
 
-    def test_major_version_too_small(self):
+    def test_major_version_too_small(self) -> None:
         self.assertFalse(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0] - 1, 0, 0)))
 
-    def test_minor_version_bigger(self):
+    def test_minor_version_bigger(self) -> None:
         self.assertTrue(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1] + 1, _SCAMP_VERSION[2])))
 
-    def test_minor_version_smaller(self):
+    def test_minor_version_smaller(self) -> None:
         self.assertFalse(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1] - 1, _SCAMP_VERSION[2])))
 
-    def test_patch_version_bigger(self):
+    def test_patch_version_bigger(self) -> None:
         self.assertTrue(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2] + 1)))
 
-    def test_patch_version_smaller(self):
+    def test_patch_version_smaller(self) -> None:
         self.assertFalse(BaseTransceiver._is_scamp_version_compabible((
             _SCAMP_VERSION[0], _SCAMP_VERSION[1], _SCAMP_VERSION[2] - 1)))
 
-    def test_compare_versions(self):
+    def test_compare_versions(self) -> None:
         spinn_utilities_parts = spinn_utilities.__version__.split('.')
         spinn_machine_parts = spinn_machine.__version__.split('.')
         spinnman_parts = spinnman.__version__.split('.')


### PR DESCRIPTION
includes 1 code change.

Transceiver init functions connections param relaxed from List to Iterable 
-especially as sorted as a set

unittests/processes_test/test_most_direct_connections_selector.py
removed "127.0.0.0" from SCAMPConnection call as it was in the chip_x position

rest are typing changes

