### PR TITLE
python_requires = >=3.8, <4, !=3.13.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ keywords =
         machine interface
 
 [options]
-python_requires = >=3.8, <4
+python_requires = >=3.8, <4, !=3.13.6
 packages = find:
 zip_safe = True
 include_package_data = True


### PR DESCRIPTION
tested by branch 3.13.6
see
https://github.com/SpiNNakerManchester/SpiNNMan/actions/runs/18156807044/job/51678477014

If we block it here it will automatically block all the higher things like sPyNNaker