### PR TITLE
close_allocation_controller protected

### DIFF
--- a/spinnman/spinnman_simulation.py
+++ b/spinnman/spinnman_simulation.py
@@ -217,7 +217,7 @@ class SpiNNManSimulation(object):
         self._data_writer.set_transceiver(transceiver)
         return (transceiver, connections)
 
-    def __close_allocation_controller(self) -> None:
+    def _close_allocation_controller(self) -> None:
         if self._data_writer.has_allocation_controller():
             self._data_writer.get_allocation_controller().close()
             self._data_writer.set_allocation_controller(None)
@@ -228,5 +228,5 @@ class SpiNNManSimulation(object):
             transceiver = self._data_writer.get_transceiver()
             transceiver.stop_application(self._data_writer.get_app_id())
 
-        self.__close_allocation_controller()
+        self._close_allocation_controller()
         self._data_writer.shut_down()


### PR DESCRIPTION
bug in https://github.com/SpiNNakerManchester/SpiNNMan/pull/456
not found due to Not found due to https://github.com/SpiNNakerManchester/IntegrationTests/pull/323

_close_allocation_controller used by other methods in ASB so can only be protected

